### PR TITLE
Add keyword parameter node type support

### DIFF
--- a/ext/rfmt/src/ast/mod.rs
+++ b/ext/rfmt/src/ast/mod.rs
@@ -66,6 +66,8 @@ pub enum NodeType {
     OptionalParameterNode,
     RestParameterNode,
     KeywordParameterNode,
+    RequiredKeywordParameterNode,
+    OptionalKeywordParameterNode,
     KeywordRestParameterNode,
     BlockParameterNode,
 
@@ -102,6 +104,8 @@ impl NodeType {
             "optional_parameter_node" => Self::OptionalParameterNode,
             "rest_parameter_node" => Self::RestParameterNode,
             "keyword_parameter_node" => Self::KeywordParameterNode,
+            "required_keyword_parameter_node" => Self::RequiredKeywordParameterNode,
+            "optional_keyword_parameter_node" => Self::OptionalKeywordParameterNode,
             "keyword_rest_parameter_node" => Self::KeywordRestParameterNode,
             "block_parameter_node" => Self::BlockParameterNode,
             _ => Self::Unknown(s.to_string()),

--- a/ext/rfmt/src/emitter/mod.rs
+++ b/ext/rfmt/src/emitter/mod.rs
@@ -660,6 +660,8 @@ impl Emitter {
                 | NodeType::OptionalParameterNode
                 | NodeType::RestParameterNode
                 | NodeType::KeywordParameterNode
+                | NodeType::RequiredKeywordParameterNode
+                | NodeType::OptionalKeywordParameterNode
                 | NodeType::KeywordRestParameterNode
                 | NodeType::BlockParameterNode
         )

--- a/spec/rfmt_spec.rb
+++ b/spec/rfmt_spec.rb
@@ -28,6 +28,37 @@ RSpec.describe Rfmt do
         Rfmt.format(invalid_source)
       end.to raise_error(Rfmt::Error)
     end
+
+    it 'formats method with required keyword parameters' do
+      source = <<~RUBY
+        def initialize(frame:, form:, tag_map:)
+          @frame = frame
+          @form = form
+          @tag_map = tag_map
+        end
+      RUBY
+
+      result = Rfmt.format(source)
+
+      expect(result).to include('def initialize(frame:, form:, tag_map:)')
+      expect(result).not_to match(/frame:\s+form:\s+tag_map:/)
+      expect(result).to include('@frame = frame')
+    end
+
+    it 'formats method with optional keyword parameters' do
+      source = <<~RUBY
+        def configure(timeout: 30, retries: 3)
+          @timeout = timeout
+          @retries = retries
+        end
+      RUBY
+
+      result = Rfmt.format(source)
+
+      expect(result).to include('def configure(timeout: 30, retries: 3)')
+      expect(result).not_to match(/timeout:\s+30\s+retries:/)
+      expect(result).to include('@timeout = timeout')
+    end
   end
 
   describe '.version_info' do


### PR DESCRIPTION
## 📋 概要
`required_keyword_parameter_node`と`optional_keyword_parameter_node`のサポートを追加し、キーワード引数を持つメソッドのフォーマットが壊れる問題を修正。

## 🐛 修正内容

### Rust側
- **ast/mod.rs**: `RequiredKeywordParameterNode`と`OptionalKeywordParameterNode`をNodeType enumに追加
- **emitter/mod.rs**: 上記ノードタイプをstructural nodeとして認識

### テスト
- **spec/rfmt_spec.rb**: 必須/オプショナルキーワードパラメータのテストケースを追加

## 🗂️ 変更ファイル
- **Rust**: `ext/rfmt/src/ast/mod.rs`, `ext/rfmt/src/emitter/mod.rs`
- **spec**: `spec/rfmt_spec.rb`

## 🧪 テスト

```bash
bundle exec rspec spec/rfmt_spec.rb
```

## 📦 破壊的変更
なし

## 関連Issue
Fixes #5