### PR TITLE
fix:  rfmtのURLを修正

### DIFF
--- a/.rfmt.yml
+++ b/.rfmt.yml
@@ -1,6 +1,6 @@
 # rfmt Configuration File
 # This file controls how rfmt formats your Ruby code.
-# See https://github.com/fujitanisora/rfmt for full documentation.
+# See https://github.com/fs0414/rfmt for full documentation.
 
 version: "1.0"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ This project adheres to the Contributor Covenant [Code of Conduct](CODE_OF_CONDU
 
 ### Finding an Issue to Work On
 
-1. Browse the [issue tracker](https://github.com/fujitanisora/rfmt/issues)
+1. Browse the [issue tracker](https://github.com/fs0414/rfmt/issues)
 2. Look for issues labeled `good first issue` or `help wanted`
 3. Comment on the issue to let others know you're working on it
 4. For larger changes, discuss your approach in the issue before starting
@@ -45,7 +45,7 @@ git clone https://github.com/YOUR_USERNAME/rfmt.git
 cd rfmt
 
 # Add the upstream repository
-git remote add upstream https://github.com/fujitanisora/rfmt.git
+git remote add upstream https://github.com/fs0414/rfmt.git
 ```
 
 ### 2. Install Dependencies
@@ -534,7 +534,7 @@ cargo doc --open
 ## Questions?
 
 - 📖 Read the [User Guide](docs/user_guide.md)
-- 💬 Ask in [Discussions](https://github.com/fujitanisora/rfmt/discussions)
+- 💬 Ask in [Discussions](https://github.com/fs0414/rfmt/discussions)
 - 📧 Email: fujitanisora0414@gmail.com
 
 ## License

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ bundle install
 ### From Source
 
 ```bash
-git clone https://github.com/fujitanisora/rfmt.git
+git clone https://github.com/fs0414/rfmt.git
 cd rfmt
 bundle install
 bundle exec rake compile
@@ -379,7 +379,7 @@ Everyone interacting in the rfmt project's codebases, issue trackers, chat rooms
 ## Support
 
 - 📖 [Documentation](docs/)
-- 🐛 [Issues](https://github.com/fujitanisora/rfmt/issues)
+- 🐛 [Issues](https://github.com/fs0414/rfmt/issues)
 - 📧 Email: fujitanisora0414@gmail.com
 
 ## Acknowledgments

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -176,8 +176,8 @@ Before each release, we verify:
 ## Contact
 
 - **Security Issues**: fujitanisora0414@gmail.com
-- **General Issues**: https://github.com/fujitanisora/rfmt/issues
-- **Discussions**: https://github.com/fujitanisora/rfmt/discussions
+- **General Issues**: https://github.com/fs0414/rfmt/issues
+- **Discussions**: https://github.com/fs0414/rfmt/discussions
 
 ## Acknowledgments
 

--- a/docs/error_reference.ja.md
+++ b/docs/error_reference.ja.md
@@ -86,8 +86,8 @@
    ```
 
 **関連Issue:**
-- [#42](https://github.com/fujitanisora/rfmt/issues/42): 構文エラーのエラーメッセージ改善
-- [#15](https://github.com/fujitanisora/rfmt/issues/15): ヒアドキュメント構文のサポート
+- [#42](https://github.com/fs0414/rfmt/issues/42): 構文エラーのエラーメッセージ改善
+- [#15](https://github.com/fs0414/rfmt/issues/15): ヒアドキュメント構文のサポート
 
 ---
 
@@ -181,7 +181,7 @@ exclude:                  # Globパターンの配列
 ```
 
 **関連Issue:**
-- [#23](https://github.com/fujitanisora/rfmt/issues/23): 設定エラーのエラーメッセージ改善
+- [#23](https://github.com/fs0414/rfmt/issues/23): 設定エラーのエラーメッセージ改善
 
 ---
 
@@ -237,7 +237,7 @@ exclude:                  # Globパターンの配列
    ```
 
 **関連Issue:**
-- [#31](https://github.com/fujitanisora/rfmt/issues/31): ロックされたファイルのエラー回復改善
+- [#31](https://github.com/fs0414/rfmt/issues/31): ロックされたファイルのエラー回復改善
 
 ---
 
@@ -289,7 +289,7 @@ exclude:                  # Globパターンの配列
    ```
 
 **関連Issue:**
-- [#55](https://github.com/fujitanisora/rfmt/issues/55): 複雑なネストブロックの処理
+- [#55](https://github.com/fs0414/rfmt/issues/55): 複雑なネストブロックの処理
 
 ---
 
@@ -330,7 +330,7 @@ exclude:                  # Globパターンの配列
    これはフォーマットルールのバグの可能性があります
 
 **関連Issue:**
-- [#67](https://github.com/fujitanisora/rfmt/issues/67): ルール競合の解決
+- [#67](https://github.com/fs0414/rfmt/issues/67): ルール競合の解決
 
 ---
 
@@ -351,7 +351,7 @@ exclude:                  # Globパターンの配列
 [Rfmt::UnsupportedFeature] 未サポート機能: ピンニング演算子を使用したパターンマッチング
 
 この機能は将来のリリースで予定されています。
-追跡: https://github.com/fujitanisora/rfmt/issues/89
+追跡: https://github.com/fs0414/rfmt/issues/89
 
 ヘルプ: https://rfmt.dev/errors/E006
 ```
@@ -386,8 +386,8 @@ exclude:                  # Globパターンの配列
 - 複雑なパターンマッチングのエッジケース
 
 **関連Issue:**
-- [#89](https://github.com/fujitanisora/rfmt/issues/89): パターンマッチングサポート
-- [#102](https://github.com/fujitanisora/rfmt/issues/102): 番号付きパラメータ
+- [#89](https://github.com/fs0414/rfmt/issues/89): パターンマッチングサポート
+- [#102](https://github.com/fs0414/rfmt/issues/102): 番号付きパラメータ
 
 ---
 
@@ -436,7 +436,7 @@ ASTのノード構造が無効です
    - エラーをトリガーするコード
 
 **関連Issue:**
-- [#118](https://github.com/fujitanisora/rfmt/issues/118): Prism 1.0互換性
+- [#118](https://github.com/fs0414/rfmt/issues/118): Prism 1.0互換性
 
 ---
 
@@ -499,7 +499,7 @@ ASTのノード構造が無効です
   at /path/to/rfmt/src/emitter.rs:123
   at /path/to/rfmt/src/formatter.rs:456
 
-これをバグとして報告してください: https://github.com/fujitanisora/rfmt/issues
+これをバグとして報告してください: https://github.com/fs0414/rfmt/issues
 
 ヘルプ: https://rfmt.dev/errors/E999
 ```
@@ -525,7 +525,7 @@ ASTのノード構造が無効です
    ```
 
 **関連Issue:**
-- [#new](https://github.com/fujitanisora/rfmt/issues/new): 新しいバグを報告
+- [#new](https://github.com/fs0414/rfmt/issues/new): 新しいバグを報告
 
 ---
 
@@ -564,9 +564,9 @@ puts Rfmt.rust_version
 
 ここでカバーされていないエラーに遭遇した場合：
 
-1. **既存のissueを検索:** https://github.com/fujitanisora/rfmt/issues
-2. **ディスカッションを確認:** https://github.com/fujitanisora/rfmt/discussions
-3. **新しいissueを作成:** https://github.com/fujitanisora/rfmt/issues/new
+1. **既存のissueを検索:** https://github.com/fs0414/rfmt/issues
+2. **ディスカッションを確認:** https://github.com/fs0414/rfmt/discussions
+3. **新しいissueを作成:** https://github.com/fs0414/rfmt/issues/new
 
 問題を報告する際は、以下を含めてください：
 

--- a/docs/error_reference.md
+++ b/docs/error_reference.md
@@ -86,8 +86,8 @@ Help: https://rfmt.dev/errors/E001
    ```
 
 **Related Issues:**
-- [#42](https://github.com/fujitanisora/rfmt/issues/42): Improved error messages for parse errors
-- [#15](https://github.com/fujitanisora/rfmt/issues/15): Support for heredoc syntax
+- [#42](https://github.com/fs0414/rfmt/issues/42): Improved error messages for parse errors
+- [#15](https://github.com/fs0414/rfmt/issues/15): Support for heredoc syntax
 
 ---
 
@@ -181,7 +181,7 @@ exclude:                  # Array of glob patterns
 ```
 
 **Related Issues:**
-- [#23](https://github.com/fujitanisora/rfmt/issues/23): Better error messages for config errors
+- [#23](https://github.com/fs0414/rfmt/issues/23): Better error messages for config errors
 
 ---
 
@@ -237,7 +237,7 @@ Help: https://rfmt.dev/errors/E003
    ```
 
 **Related Issues:**
-- [#31](https://github.com/fujitanisora/rfmt/issues/31): Better error recovery for locked files
+- [#31](https://github.com/fs0414/rfmt/issues/31): Better error recovery for locked files
 
 ---
 
@@ -289,7 +289,7 @@ Help: https://rfmt.dev/errors/E004
    ```
 
 **Related Issues:**
-- [#55](https://github.com/fujitanisora/rfmt/issues/55): Handling of complex nested blocks
+- [#55](https://github.com/fs0414/rfmt/issues/55): Handling of complex nested blocks
 
 ---
 
@@ -330,7 +330,7 @@ Help: https://rfmt.dev/errors/E005
    This is likely a bug in the formatting rules
 
 **Related Issues:**
-- [#67](https://github.com/fujitanisora/rfmt/issues/67): Rule conflict resolution
+- [#67](https://github.com/fs0414/rfmt/issues/67): Rule conflict resolution
 
 ---
 
@@ -351,7 +351,7 @@ Help: https://rfmt.dev/errors/E005
 [Rfmt::UnsupportedFeature] Unsupported feature: Pattern matching with pinning operator
 
 This feature is planned for a future release.
-Please track: https://github.com/fujitanisora/rfmt/issues/89
+Please track: https://github.com/fs0414/rfmt/issues/89
 
 Help: https://rfmt.dev/errors/E006
 ```
@@ -386,8 +386,8 @@ Help: https://rfmt.dev/errors/E006
 - Complex pattern matching edge cases
 
 **Related Issues:**
-- [#89](https://github.com/fujitanisora/rfmt/issues/89): Pattern matching support
-- [#102](https://github.com/fujitanisora/rfmt/issues/102): Numbered parameters
+- [#89](https://github.com/fs0414/rfmt/issues/89): Pattern matching support
+- [#102](https://github.com/fs0414/rfmt/issues/102): Numbered parameters
 
 ---
 
@@ -436,7 +436,7 @@ Help: https://rfmt.dev/errors/E007
    - Code that triggers the error
 
 **Related Issues:**
-- [#118](https://github.com/fujitanisora/rfmt/issues/118): Prism 1.0 compatibility
+- [#118](https://github.com/fs0414/rfmt/issues/118): Prism 1.0 compatibility
 
 ---
 
@@ -499,7 +499,7 @@ Backtrace:
   at /path/to/rfmt/src/emitter.rs:123
   at /path/to/rfmt/src/formatter.rs:456
 
-Please report this as a bug at: https://github.com/fujitanisora/rfmt/issues
+Please report this as a bug at: https://github.com/fs0414/rfmt/issues
 
 Help: https://rfmt.dev/errors/E999
 ```
@@ -525,7 +525,7 @@ Help: https://rfmt.dev/errors/E999
    ```
 
 **Related Issues:**
-- [#new](https://github.com/fujitanisora/rfmt/issues/new): Report new bug
+- [#new](https://github.com/fs0414/rfmt/issues/new): Report new bug
 
 ---
 
@@ -564,9 +564,9 @@ puts Rfmt.rust_version
 
 If you encounter an error not covered here:
 
-1. **Search existing issues:** https://github.com/fujitanisora/rfmt/issues
-2. **Check discussions:** https://github.com/fujitanisora/rfmt/discussions
-3. **Create a new issue:** https://github.com/fujitanisora/rfmt/issues/new
+1. **Search existing issues:** https://github.com/fs0414/rfmt/issues
+2. **Check discussions:** https://github.com/fs0414/rfmt/discussions
+3. **Create a new issue:** https://github.com/fs0414/rfmt/issues/new
 
 When reporting issues, include:
 

--- a/docs/user_guide.ja.md
+++ b/docs/user_guide.ja.md
@@ -28,7 +28,7 @@ gem install rfmt
 ### ソースからインストール
 
 ```bash
-git clone https://github.com/fujitanisora/rfmt.git
+git clone https://github.com/fs0414/rfmt.git
 cd rfmt
 bundle install
 bundle exec rake compile
@@ -385,7 +385,7 @@ formatting:
 
 **原因:** コードがrfmtでまだサポートされていないRuby機能を使用
 
-**解決方法:** [ロードマップ](https://github.com/fujitanisora/rfmt/blob/main/ROADMAP.md)を確認するか、issueを作成
+**解決方法:** [ロードマップ](https://github.com/fs0414/rfmt/blob/main/ROADMAP.md)を確認するか、issueを作成
 
 ## トラブルシューティング
 
@@ -541,8 +541,8 @@ rfmtは **Ruby 3.0以上** をサポートします。以下でテストして�
 ### ヘルプはどこで得られますか？
 
 - 📖 ドキュメント: https://rfmt.dev/docs
-- 🐛 Issues: https://github.com/fujitanisora/rfmt/issues
-- 💬 Discussions: https://github.com/fujitanisora/rfmt/discussions
+- 🐛 Issues: https://github.com/fs0414/rfmt/issues
+- 💬 Discussions: https://github.com/fs0414/rfmt/discussions
 - 📧 Email: fujitanisora0414@gmail.com
 
 ## 次のステップ

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -28,7 +28,7 @@ gem install rfmt
 ### Install from Source
 
 ```bash
-git clone https://github.com/fujitanisora/rfmt.git
+git clone https://github.com/fs0414/rfmt.git
 cd rfmt
 bundle install
 bundle exec rake compile
@@ -384,7 +384,7 @@ formatting:
 
 **Cause:** Code uses a Ruby feature not yet supported by rfmt
 
-**Solution:** Check the [roadmap](https://github.com/fujitanisora/rfmt/blob/main/ROADMAP.md) or file an issue
+**Solution:** Check the [roadmap](https://github.com/fs0414/rfmt/blob/main/ROADMAP.md) or file an issue
 
 ## Troubleshooting
 
@@ -540,8 +540,8 @@ See our [Contributing Guide](../CONTRIBUTING.md) for details on:
 ### Where can I get help?
 
 - 📖 Documentation: https://rfmt.dev/docs
-- 🐛 Issues: https://github.com/fujitanisora/rfmt/issues
-- 💬 Discussions: https://github.com/fujitanisora/rfmt/discussions
+- 🐛 Issues: https://github.com/fs0414/rfmt/issues
+- 💬 Discussions: https://github.com/fs0414/rfmt/discussions
 - 📧 Email: fujitanisora0414@gmail.com
 
 ## Next Steps

--- a/lib/rfmt.rb
+++ b/lib/rfmt.rb
@@ -61,7 +61,7 @@ module Rfmt
     DEFAULT_CONFIG = <<~YAML
       # rfmt Configuration File
       # This file controls how rfmt formats your Ruby code.
-      # See https://github.com/fujitanisora/rfmt for full documentation.
+      # See https://github.com/fs0414/rfmt for full documentation.
 
       version: "1.0"
 


### PR DESCRIPTION
## 📋 概要
rfmtリポジトリのURLが異なっていたので修正しました

## 🔧 主な変更内容
リポジトリのURLの修正

修正前：`https://github.com/fujitanisora/rfmt`
修正後：`https://github.com/fs0414/rfmt`

## 🗂️ 変更ファイル
- .rfmt.yml
- CONTRIBUTING.md
- README.md
- docs
   - SECURITY.md
   - error_reference.ja.md
   - error_reference.md
   - user_guide.ja.md
   - user_guide.md
- lib/rfmt.rb

## 🧪 テスト
コメントあるいはmdファイルでの変更でありコードに影響がないため未実行

## 📦 破壊的変更
なし