### PR TITLE
Add case/when statement support

### DIFF
--- a/lib/rfmt/prism_bridge.rb
+++ b/lib/rfmt/prism_bridge.rb
@@ -210,6 +210,10 @@ module Rfmt
                      node.parts || []
                    when Prism::EmbeddedStatementsNode
                      [node.statements].compact
+                   when Prism::CaseNode
+                     [node.predicate, *node.conditions, node.else_clause].compact
+                   when Prism::WhenNode
+                     [*node.conditions, node.statements].compact
                    else
                      # For unknown types, try to get child nodes if they exist
                      []

--- a/spec/case_formatting_spec.rb
+++ b/spec/case_formatting_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Rfmt, 'Case/When Formatting' do
+  describe 'basic case statement' do
+    it 'formats simple case' do
+      source = "case x\nwhen 1\n\"one\"\nwhen 2\n\"two\"\nend"
+      result = Rfmt.format(source)
+      expect(result).to include('case x')
+      expect(result).to include('when 1')
+      expect(result).to include('when 2')
+      expect(result).to include('end')
+    end
+  end
+
+  describe 'case with else' do
+    it 'formats case-when-else' do
+      source = "case status\nwhen :pending\nprocess_pending\nelse\nhandle_unknown\nend"
+      result = Rfmt.format(source)
+      expect(result).to include('case status')
+      expect(result).to include('when :pending')
+      expect(result).to include('else')
+      expect(result).to include('end')
+    end
+  end
+
+  describe 'case without predicate' do
+    it 'formats case-when-true pattern' do
+      source = "case\nwhen x > 0\n\"positive\"\nwhen x < 0\n\"negative\"\nend"
+      result = Rfmt.format(source)
+      expect(result).to include('case')
+      expect(result).to include('when x > 0')
+      expect(result).to include('when x < 0')
+    end
+  end
+
+  describe 'multiple when conditions' do
+    it 'formats when with multiple values' do
+      source = "case char\nwhen 'a', 'e', 'i'\n\"vowel\"\nend"
+      result = Rfmt.format(source)
+      expect(result).to include("when 'a', 'e', 'i'")
+    end
+  end
+
+  describe 'case in method' do
+    it 'formats nested case with proper indentation' do
+      source = "def classify(value)\ncase value\nwhen Integer\n\"number\"\nwhen String\n\"text\"\nend\nend"
+      result = Rfmt.format(source)
+      expect(result).to include('def classify(value)')
+      expect(result).to include('case value')
+      expect(result).to include('when Integer')
+      expect(result).to include('end')
+    end
+  end
+
+  describe 'case with class matching' do
+    it 'formats case with class conditions' do
+      source = "case obj\nwhen Array\nhandle_array\nwhen Hash\nhandle_hash\nend"
+      result = Rfmt.format(source)
+      expect(result).to include('when Array')
+      expect(result).to include('when Hash')
+    end
+  end
+
+  describe 'case with range matching' do
+    it 'formats case with range conditions' do
+      source = "case age\nwhen 0..12\n\"child\"\nwhen 13..19\n\"teenager\"\nend"
+      result = Rfmt.format(source)
+      expect(result).to include('when 0..12')
+      expect(result).to include('when 13..19')
+    end
+  end
+
+  describe 'multiline when body' do
+    it 'formats when with multiple statements' do
+      source = "case action\nwhen :create\nvalidate\nsave\nwhen :delete\narchive\nend"
+      result = Rfmt.format(source)
+      expect(result).to include('validate')
+      expect(result).to include('save')
+      expect(result).to include('archive')
+    end
+  end
+
+  describe 'nested case statements' do
+    it 'formats nested case' do
+      source = "case category\nwhen :animal\ncase species\nwhen :dog\n\"bark\"\nend\nwhen :vehicle\n\"vroom\"\nend"
+      result = Rfmt.format(source)
+      expect(result.scan('case').count).to eq(2)
+      expect(result.scan('end').count).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
## 📋 Overview
Add support for `case/when/else` statement formatting in rfmt. This completes PR#3 of Issue #18.

## 🔧 Main Changes

### Core Implementation
- **CaseNode support**: Extract predicate, when conditions, and else clause as children
- **WhenNode support**: Extract conditions and statements body
- **emit_case**: Handle case with/without predicate, emit when clauses and else
- **emit_when**: Emit conditions with comma separator and indented body

### Features Supported
- `case x when ... end` (with predicate)
- `case when ... end` (without predicate)
- Multiple conditions: `when 1, 2, 3`
- `else` clause handling
- Nested case statements
- Case inside methods with proper indentation

## 🗂️ Changed Files
- **Ruby side**: `lib/rfmt/prism_bridge.rb`
- **Rust side**: `ext/rfmt/src/emitter/mod.rs`
- **Tests**: `spec/case_formatting_spec.rb`

## 🧪 Testing

### How to Run Tests
```bash
bundle exec rake compile
bundle exec rspec spec/case_formatting_spec.rb
```

### Test Results
- Test count: 104 examples, 0 failures (+9 case/when tests)

### Verification Items
- [x] Simple case/when formats correctly
- [x] Case with else clause works
- [x] Case without predicate (`case when x > 0`) works
- [x] Multiple when conditions (`when 1, 2, 3`) joined with commas
- [x] Case inside method has proper indentation
- [x] Nested case statements work
- [x] No rubocop offenses

## 📦 Breaking Changes
None

## Related Issue
Related to #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>