### PR TITLE
GitHub Issue/PR テンプレートの追加

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,117 @@
+name: Bug Report
+description: Report a bug in rfmt
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the form below to help us investigate.
+
+  - type: input
+    id: rfmt-version
+    attributes:
+      label: rfmt version
+      description: Run `rfmt --version` or check your Gemfile.lock
+      placeholder: "1.2.7"
+    validations:
+      required: true
+
+  - type: input
+    id: ruby-version
+    attributes:
+      label: Ruby version
+      description: Run `ruby -v`
+      placeholder: "ruby 3.3.0 (2023-12-25 revision 5124f9ac75)"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - macOS (Apple Silicon)
+        - macOS (Intel)
+        - Linux (x86_64)
+        - Linux (ARM64)
+        - Windows (WSL)
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of what the bug is.
+      placeholder: Describe what happened...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+      placeholder: Describe what you expected...
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+      placeholder: Describe what actually happened...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction Code
+      description: |
+        Minimal Ruby code that reproduces the issue.
+        This will be automatically formatted as Ruby code.
+      render: ruby
+      placeholder: |
+        # Minimal code to reproduce
+        class Example
+          def foo
+            # ...
+          end
+        end
+    validations:
+      required: true
+
+  - type: textarea
+    id: error-output
+    attributes:
+      label: Error Output
+      description: |
+        Full error message or unexpected output.
+        This will be automatically formatted as a code block.
+      render: shell
+      placeholder: |
+        $ rfmt example.rb
+        Error: ...
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Configuration (if applicable)
+      description: |
+        Contents of your rfmt.yml if you're using custom configuration.
+        This will be automatically formatted as YAML.
+      render: yaml
+      placeholder: |
+        formatting:
+          line_length: 100
+          indent_width: 2
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context about the problem (screenshots, related issues, etc.)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://github.com/fs0414/rfmt/blob/main/docs/user_guide.md
+    about: Check the user guide before opening an issue
+  - name: Discussions
+    url: https://github.com/fs0414/rfmt/discussions
+    about: Ask questions and discuss ideas
+  - name: Contributing Guide
+    url: https://github.com/fs0414/rfmt/blob/main/CONTRIBUTING.md
+    about: Learn how to contribute to rfmt

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,75 @@
+name: Feature Request
+description: Suggest a new feature or enhancement for rfmt
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please fill out the form below.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: |
+        Is your feature request related to a problem?
+        A clear description of what the problem is.
+      placeholder: "I'm always frustrated when..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: A clear description of what you want to happen.
+      placeholder: "I would like rfmt to..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or features you've considered.
+      placeholder: "I also considered..."
+
+  - type: textarea
+    id: examples
+    attributes:
+      label: Code Examples
+      description: |
+        If applicable, provide before/after code examples.
+        This will be automatically formatted as Ruby code.
+      render: ruby
+      placeholder: |
+        # Before (current behavior)
+        def foo(a,b,c)
+        end
+
+        # After (desired behavior)
+        def foo(a, b, c)
+        end
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How important is this feature to you?
+      options:
+        - Nice to have
+        - Would help my workflow
+        - Blocking my adoption of rfmt
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      description: Would you be interested in contributing this feature?
+      options:
+        - label: I'm willing to submit a PR for this feature
+        - label: I can help with testing
+        - label: I can help with documentation

--- a/.github/ISSUE_TEMPLATE/node_support.yml
+++ b/.github/ISSUE_TEMPLATE/node_support.yml
@@ -1,0 +1,112 @@
+name: Node Type Support
+description: Request support for a Ruby/Prism node type
+title: "[Node]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Request support for a Prism node type that rfmt doesn't currently handle correctly.
+
+  - type: input
+    id: node-type
+    attributes:
+      label: Node Type
+      description: The Prism node type name (e.g., CaseMatchNode, MatchPredicateNode)
+      placeholder: "CaseMatchNode"
+    validations:
+      required: true
+
+  - type: textarea
+    id: ruby-syntax
+    attributes:
+      label: Ruby Syntax
+      description: |
+        The Ruby syntax that uses this node type.
+        This will be automatically formatted as Ruby code.
+      render: ruby
+      placeholder: |
+        case value
+        in [1, 2, 3]
+          puts "array"
+        in { key: value }
+          puts "hash"
+        end
+    validations:
+      required: true
+
+  - type: textarea
+    id: current-output
+    attributes:
+      label: Current Output
+      description: What does rfmt currently output for this syntax?
+      render: ruby
+      placeholder: |
+        # Current (broken) output:
+        case value
+        in [1, 2, 3]puts "array"
+        end
+
+  - type: textarea
+    id: expected-output
+    attributes:
+      label: Expected Output
+      description: What should rfmt output?
+      render: ruby
+      placeholder: |
+        # Expected output:
+        case value
+        in [1, 2, 3]
+          puts "array"
+        in { key: value }
+          puts "hash"
+        end
+    validations:
+      required: true
+
+  - type: dropdown
+    id: usage-context
+    attributes:
+      label: Usage Context
+      description: Where is this syntax commonly used?
+      options:
+        - Rails applications
+        - General Ruby applications
+        - Ruby 3.x pattern matching
+        - DSL / metaprogramming
+        - Testing frameworks (RSpec, etc.)
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How commonly is this syntax used?
+      options:
+        - Low (rare edge case)
+        - Medium (occasionally used)
+        - High (commonly used in production code)
+        - Critical (blocking adoption)
+    validations:
+      required: true
+
+  - type: textarea
+    id: prism-ast
+    attributes:
+      label: Prism AST (optional)
+      description: |
+        If you have the Prism AST output, include it here.
+        Run: `ruby -rprism -e "pp Prism.parse('your code').value"`
+      render: ruby
+      placeholder: |
+        # Output of Prism.parse(...).value
+        @ ProgramNode (location: ...)
+        └── ...
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other relevant information (related issues, workarounds, etc.)

--- a/.github/ISSUE_TEMPLATE/refactoring.yml
+++ b/.github/ISSUE_TEMPLATE/refactoring.yml
@@ -1,0 +1,139 @@
+name: Refactoring Proposal
+description: Propose a code refactoring for improved testability, maintainability, or type safety
+title: "[Refactor]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing a refactoring! This template is for internal code improvements that don't change external behavior.
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Refactoring Category
+      description: What aspect of the code does this improve?
+      options:
+        - Testability (make code easier to test)
+        - Maintainability (improve code organization)
+        - Type Safety (leverage Rust/Ruby type systems)
+        - Performance (optimize without changing behavior)
+        - Code Quality (reduce complexity, improve readability)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: layer
+    attributes:
+      label: Affected Layer
+      description: Which part of the codebase is affected?
+      options:
+        - Rust - Emitter (ext/rfmt/src/emitter/)
+        - Rust - AST (ext/rfmt/src/ast/)
+        - Rust - Config (ext/rfmt/src/config/)
+        - Rust - Parser (ext/rfmt/src/parser/)
+        - Rust - Error Handling (ext/rfmt/src/error/)
+        - Ruby - PrismBridge (lib/rfmt/)
+        - Ruby - CLI (exe/)
+        - Multiple layers
+    validations:
+      required: true
+
+  - type: textarea
+    id: current-state
+    attributes:
+      label: Current State
+      description: |
+        Describe the current implementation and its problems.
+        Include file paths and line numbers if possible.
+      placeholder: |
+        **File:** `ext/rfmt/src/emitter/mod.rs:85`
+
+        **Current code:**
+        ```rust
+        if self.emitted_comment_indices.contains(&idx) {
+            continue;
+        }
+        ```
+
+        **Problem:** Linear search O(n) on every comment check
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-change
+    attributes:
+      label: Proposed Change
+      description: |
+        Describe the refactoring with code examples.
+      placeholder: |
+        **Proposed code:**
+        ```rust
+        // Use HashSet for O(1) lookup
+        emitted_comment_indices: HashSet<usize>,
+        ```
+
+        **Benefits:**
+        - O(1) lookup instead of O(n)
+        - Better performance for files with many comments
+    validations:
+      required: true
+
+  - type: textarea
+    id: files-to-modify
+    attributes:
+      label: Files to Modify
+      description: List all files that need to be changed.
+      placeholder: |
+        - `ext/rfmt/src/emitter/mod.rs`
+          - Line 1: Add import
+          - Line 19: Change type
+          - Lines 29, 41: Update constructors
+    validations:
+      required: true
+
+  - type: dropdown
+    id: breaking-change
+    attributes:
+      label: Breaking Change?
+      description: Does this change break any public API?
+      options:
+        - "No - internal refactoring only"
+        - "Yes - but backward compatible"
+        - "Yes - breaking change required"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: effort
+    attributes:
+      label: Estimated Effort
+      options:
+        - Small (< 1 hour)
+        - Medium (1-4 hours)
+        - Large (4-8 hours)
+        - Very Large (> 8 hours)
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: How do we know when this refactoring is complete?
+      placeholder: |
+        - [ ] All existing tests pass
+        - [ ] New unit tests added for the refactored code
+        - [ ] `cargo clippy` reports no new warnings
+        - [ ] Performance benchmark shows improvement (if applicable)
+    validations:
+      required: true
+
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks & Mitigations
+      description: Any risks associated with this change and how to mitigate them.
+      placeholder: |
+        **Risk:** Might introduce subtle behavior changes
+        **Mitigation:** Add property-based tests to verify idempotency

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,77 @@
+## Description
+
+<!-- Brief description of what this PR does -->
+
+## Motivation
+
+<!-- Why is this change needed? Link to related issues if applicable -->
+
+Fixes #
+Related to #
+
+## Changes
+
+<!-- List the main changes made in this PR -->
+
+-
+-
+-
+
+## Type of Change
+
+<!-- Check all that apply -->
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Refactoring (no functional changes, improves code quality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Documentation update
+- [ ] Test addition/update
+
+## Testing
+
+<!-- Describe how you tested your changes -->
+
+- [ ] All existing tests pass (`bundle exec rspec`)
+- [ ] Rust tests pass (`cd ext/rfmt && cargo test`)
+- [ ] Added new tests for new functionality
+- [ ] Manually tested with the following scenarios:
+  -
+
+## Checklist
+
+<!-- Ensure all items are checked before requesting review -->
+
+- [ ] My code follows the project's code style
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code in hard-to-understand areas
+- [ ] I have updated documentation if needed
+- [ ] My changes generate no new warnings (`cargo clippy`)
+- [ ] I have added tests that prove my fix/feature works
+
+## Screenshots / Examples
+
+<!-- If applicable, add screenshots or code examples showing the change -->
+
+<details>
+<summary>Before</summary>
+
+```ruby
+# Code before the change
+```
+
+</details>
+
+<details>
+<summary>After</summary>
+
+```ruby
+# Code after the change
+```
+
+</details>
+
+## Additional Notes
+
+<!-- Any other information reviewers should know -->
+


### PR DESCRIPTION
## 📋 概要

GitHub Issue と Pull Request のテンプレートを追加し、コントリビューターが統一されたフォーマットで報告・提案できるようにします。

## 🔧 主な変更内容

### Issue テンプレート (YAML形式)
- **Bug Report**: バグ報告用フォームテンプレート
  - rfmt/Rubyバージョン、OS情報
  - 再現コード（Rubyシンタックスハイライト付き）
  - エラー出力、設定ファイル
- **Feature Request**: 機能リクエスト用テンプレート
  - 問題点、解決策、コード例
  - 優先度選択、コントリビュート意向
- **Refactoring Proposal**: リファクタリング提案用テンプレート
  - カテゴリ（テスタビリティ、保守性、型安全性など）
  - 対象レイヤー、現状/提案コード、工数見積もり
- **Node Type Support**: Prismノードタイプ対応リクエスト用
  - ノード名、Ruby構文、現在/期待出力
  - 使用コンテキスト、優先度

### テンプレート設定
- **config.yml**: ブランクIssueを無効化、関連リンク（ドキュメント、Discussions、Contributing Guide）を表示

### PR テンプレート
- **PULL_REQUEST_TEMPLATE.md**: 標準的なPRフォーマット
  - 変更概要、動機、変更タイプ
  - テスト実行チェックリスト
  - Before/After コード例セクション

## 🗂️ 変更ファイル

- **Issue テンプレート**: `.github/ISSUE_TEMPLATE/bug_report.yml`, `feature_request.yml`, `refactoring.yml`, `node_support.yml`, `config.yml`
- **PR テンプレート**: `.github/PULL_REQUEST_TEMPLATE.md`

## 🧪 テスト

### 検証項目
- [x] YAML構文が正しいことを確認
- [x] CONTRIBUTING.md との整合性を確認
- [x] 既存の release_template.md と競合しないことを確認

## 📦 破壊的変更

なし - 新規ファイルの追加のみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>