### PR TITLE
プリコンパイル済みgemの配布対応 - ユーザー環境でのCargo依存を解消

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,24 +49,21 @@ jobs:
         fi
         echo "CHANGELOG.md is up to date"
 
-  build:
-    name: Build gem for ${{ matrix.platform }}
+  build-native:
+    name: Build native gem (${{ matrix.platform }})
     needs: validate
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        include:
-          - os: ubuntu-latest
-            platform: x86_64-linux
-          - os: ubuntu-latest
-            platform: aarch64-linux
-          - os: macos-latest
-            platform: x86_64-darwin
-          - os: macos-latest
-            platform: arm64-darwin
-          - os: windows-latest
-            platform: x64-mingw-ucrt
-
+        platform:
+          - x86_64-linux
+          - x86_64-linux-musl
+          - aarch64-linux
+          - aarch64-linux-musl
+          - x86_64-darwin
+          - arm64-darwin
+          - x64-mingw-ucrt
     steps:
     - uses: actions/checkout@v4
 
@@ -76,20 +73,44 @@ jobs:
         ruby-version: '3.3'
         bundler-cache: true
 
-    - name: Build native gem
-      run: bundle exec rake native:${{ matrix.platform }}:gem
-      continue-on-error: true
+    - uses: oxidize-rb/actions/cross-gem@v1
+      with:
+        platform: ${{ matrix.platform }}
+        ruby-versions: '3.1,3.2,3.3'
 
     - name: Upload gem artifact
       uses: actions/upload-artifact@v4
       with:
         name: gem-${{ matrix.platform }}
-        path: pkg/*.gem
-        if-no-files-found: warn
+        path: pkg/*-${{ matrix.platform }}.gem
+        if-no-files-found: error
+
+  build-source:
+    name: Build source gem
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.3'
+        bundler-cache: true
+
+    - name: Build source gem
+      run: gem build rfmt.gemspec
+
+    - name: Upload gem artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: gem-source
+        path: '*.gem'
+        if-no-files-found: error
 
   release:
     name: Create GitHub Release
-    needs: build
+    needs: [build-native, build-source]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -114,6 +135,9 @@ jobs:
       with:
         path: artifacts
 
+    - name: Display downloaded artifacts
+      run: find artifacts -type f -name "*.gem" | head -20
+
     - name: Create Release
       uses: softprops/action-gh-release@v1
       with:
@@ -130,6 +154,17 @@ jobs:
           gem install rfmt -v ${{ steps.extract_version.outputs.tag_version }}
           ```
 
+          ### Precompiled platforms
+
+          This release includes precompiled native gems for:
+          - Linux x86_64 (glibc and musl)
+          - Linux aarch64 (glibc and musl)
+          - macOS x86_64 (Intel)
+          - macOS arm64 (Apple Silicon)
+          - Windows x64
+
+          If a precompiled gem is not available for your platform, the source gem will be installed and compiled using Cargo.
+
           ## Full Changelog
 
           See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/v${{ steps.extract_version.outputs.tag_version }}/CHANGELOG.md) for all changes.
@@ -143,23 +178,35 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-    - uses: actions/checkout@v4
-
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+    - name: Download all artifacts
+      uses: actions/download-artifact@v4
       with:
-        ruby-version: '3.3'
-        bundler-cache: true
+        path: artifacts
 
-    - name: Build gem
-      run: bundle exec rake build
+    - name: Display gems to publish
+      run: find artifacts -type f -name "*.gem" | sort
 
-    - name: Publish to RubyGems
+    - name: Publish all gems to RubyGems
       run: |
         mkdir -p ~/.gem
         echo ":rubygems_api_key: ${{ secrets.RUBYGEMS_API_KEY }}" > ~/.gem/credentials
         chmod 0600 ~/.gem/credentials
-        gem push pkg/*.gem
+
+        # Publish source gem first
+        for gem in artifacts/gem-source/*.gem; do
+          if [ -f "$gem" ]; then
+            echo "Publishing source gem: $gem"
+            gem push "$gem" || echo "Failed to push $gem (may already exist)"
+          fi
+        done
+
+        # Then publish platform-specific gems
+        for gem in artifacts/gem-*/*.gem; do
+          if [ -f "$gem" ] && [[ "$gem" != *"gem-source"* ]]; then
+            echo "Publishing: $gem"
+            gem push "$gem" || echo "Failed to push $gem (may already exist)"
+          fi
+        done
       if: env.RUBYGEMS_API_KEY != ''
       env:
         RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}

--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,16 @@ GEMSPEC = Gem::Specification.load('rfmt.gemspec')
 
 RbSys::ExtensionTask.new('rfmt', GEMSPEC) do |ext|
   ext.lib_dir = 'lib/rfmt'
+  ext.cross_compile = true
+  ext.cross_platform = %w[
+    x86_64-linux
+    x86_64-linux-musl
+    aarch64-linux
+    aarch64-linux-musl
+    x86_64-darwin
+    arm64-darwin
+    x64-mingw-ucrt
+  ]
 end
 
 task default: %i[compile spec rubocop]

--- a/rfmt.gemspec
+++ b/rfmt.gemspec
@@ -22,28 +22,9 @@ Gem::Specification.new do |spec|
   spec.metadata['ruby_lsp_addon'] = 'true'
 
   # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  gemspec = File.basename(__FILE__)
-  spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
-    ls.readlines("\x0", chomp: true).reject do |f|
-      (f == gemspec) ||
-        f.start_with?(*%w[bin/ Gemfile .gitignore .rspec spec/ .github/ .rubocop.yml])
-    end
-  end
-  spec.bindir = 'exe'
-  spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
-  spec.require_paths = ['lib']
-  spec.extensions = ['ext/rfmt/extconf.rb']
-
-  # Uncomment to register a new dependency of your gem
-  # spec.add_dependency 'example-gem', '~> 1.0'
-  spec.add_dependency 'rb_sys', '~> 0.9.91'
-
-  # For more information and examples about making a new gem, check out our
-  # guide at: https://bundler.io/guides/creating_gem.html
-
+  # Explicitly list files to avoid including compiled artifacts (.bundle, .so)
   spec.files = Dir[
-    'lib/**/*',
+    'lib/**/*.rb',
     'ext/**/*.{rb,rs,toml}',
     'Cargo.toml',
     'Cargo.lock',
@@ -51,5 +32,10 @@ Gem::Specification.new do |spec|
     'LICENSE.txt',
     'CHANGELOG.md'
   ]
+  spec.bindir = 'exe'
+  spec.executables = ['rfmt']
   spec.require_paths = ['lib']
+  spec.extensions = ['ext/rfmt/extconf.rb']
+
+  spec.add_dependency 'rb_sys', '~> 0.9.91'
 end


### PR DESCRIPTION
## 📋 概要

ユーザーが`gem install rfmt`や`bundle install`でrfmtをインストールする際、**Rustツールチェーン（cargo, rustc）が不要**になるよう、プリコンパイル済みネイティブgemの配布に対応しました。

### 背景
Alpine Linuxベースのコンテナなど、Rustがインストールされていない環境でインストールが失敗する報告がありました（#30）。

```
checking for cargo... no
/bin/sh: curl: not found
make: *** [Makefile:542: .rb-sys/stable/cargo/bin/cargo] Error 127
```

## 🔧 主な変更内容

### ビルド設定 (Rakefile)
- **クロスコンパイル設定**: `RbSys::ExtensionTask`に7プラットフォームのクロスコンパイル設定を追加
  - `x86_64-linux` / `x86_64-linux-musl` (Alpine Linux対応)
  - `aarch64-linux` / `aarch64-linux-musl`
  - `x86_64-darwin` (Intel Mac) / `arm64-darwin` (Apple Silicon)
  - `x64-mingw-ucrt` (Windows)

### CI/CDワークフロー (.github/workflows/release.yml)
- **oxidize-rb/actions/cross-gem**: 公式のクロスコンパイルActionに移行
- **ソースgem + ネイティブgem**: ソースgemとプラットフォーム別ネイティブgemを両方配布
- **Ruby 3.1/3.2/3.3対応**: 各プラットフォームで3バージョンのRuby向けにビルド
- **自動公開**: リリース時にすべてのgemをRubyGemsに自動公開

### gemspec修正
- **ファイルパターン修正**: `lib/**/*` → `lib/**/*.rb` に変更し、コンパイル済みバイナリ(`.bundle`, `.so`)の誤同梱を防止

## 🗂️ 変更ファイル
- **ビルド設定**: `Rakefile`
- **CI/CD**: `.github/workflows/release.yml`
- **パッケージ定義**: `rfmt.gemspec`

## 🧪 テスト

### テスト実行方法
```bash
bundle exec rake compile && bundle exec rspec
```

### テスト結果
- テスト件数: 60 examples, 0 failures

### 検証項目
- [x] ソースgemのビルド成功
- [x] 全テストパス
- [x] gemspecからコンパイル済みバイナリが除外されている

## 📦 破壊的変更
なし - 既存のインストール方法は引き続き動作します。

## 🔄 動作の変更

| 環境 | 変更前 | 変更後 |
|-----|-------|-------|
| プリコンパイル対応プラットフォーム | Cargoでビルド | プリコンパイル済みを使用 |
| 非対応プラットフォーム | Cargoでビルド | Cargoでビルド（変更なし） |

## 関連Issue
Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>