### PR TITLE
fix: address clippy warnings

### DIFF
--- a/ext/rfmt/src/error/mod.rs
+++ b/ext/rfmt/src/error/mod.rs
@@ -29,7 +29,7 @@ impl From<std::fmt::Error> for RfmtError {
 }
 
 impl RfmtError {
-    /// Convert RfmtError to Magnus Error for Ruby interop
+    /// Convert `RfmtError` to Magnus `Error` for Ruby interop
     pub fn to_magnus_error(&self, ruby: &Ruby) -> MagnusError {
         let exception_class = match self {
             RfmtError::PrismError(_) => "PrismError",

--- a/ext/rfmt/src/parser/prism_adapter.rs
+++ b/ext/rfmt/src/parser/prism_adapter.rs
@@ -13,8 +13,8 @@ impl PrismAdapter {
         Self
     }
 
-    /// Parse JSON from Ruby's PrismBridge
-    fn parse_json(&self, json: &str) -> Result<(PrismNode, Vec<PrismComment>)> {
+    /// Parse JSON from Ruby's `PrismBridge`
+    fn parse_json(json: &str) -> Result<(PrismNode, Vec<PrismComment>)> {
         // Try to parse as new format with comments first
         if let Ok(wrapper) = serde_json::from_str::<PrismWrapper>(json) {
             return Ok((wrapper.ast, wrapper.comments));
@@ -26,8 +26,8 @@ impl PrismAdapter {
         Ok((node, Vec::new()))
     }
 
-    /// Convert PrismNode to internal Node representation
-    fn convert_node(&self, prism_node: &PrismNode) -> Result<Node> {
+    /// Convert `PrismNode` to internal `Node` representation
+    fn convert_node(prism_node: &PrismNode) -> Result<Node> {
         // Convert node type (always succeeds, returns Unknown for unsupported types)
         let node_type = NodeType::from_str(&prism_node.node_type);
 
@@ -42,18 +42,15 @@ impl PrismAdapter {
         );
 
         // Convert children recursively
-        let children: Result<Vec<Node>> = prism_node
-            .children
-            .iter()
-            .map(|child| self.convert_node(child))
-            .collect();
+        let children: Result<Vec<Node>> =
+            prism_node.children.iter().map(Self::convert_node).collect();
         let children = children?;
 
         // Convert comments
         let comments: Vec<Comment> = prism_node
             .comments
             .iter()
-            .map(|c| self.convert_comment(c))
+            .map(Self::convert_comment)
             .collect();
 
         // Convert formatting info
@@ -76,19 +73,17 @@ impl PrismAdapter {
         })
     }
 
-    /// Convert PrismComment to internal Comment
-    fn convert_comment(&self, comment: &PrismComment) -> Comment {
+    /// Convert `PrismComment` to internal `Comment`
+    fn convert_comment(comment: &PrismComment) -> Comment {
         let comment_type = match comment.comment_type.as_str() {
-            "line" => CommentType::Line,
             "block" => CommentType::Block,
-            _ => CommentType::Line, // default to line comment
+            _ => CommentType::Line,
         };
 
         let position = match comment.position.as_str() {
-            "leading" => CommentPosition::Leading,
             "trailing" => CommentPosition::Trailing,
             "inner" => CommentPosition::Inner,
-            _ => CommentPosition::Leading, // default to leading
+            _ => CommentPosition::Leading,
         };
 
         Comment {
@@ -109,13 +104,13 @@ impl PrismAdapter {
 
 impl RubyParser for PrismAdapter {
     fn parse(&self, json: &str) -> Result<Node> {
-        let (prism_ast, top_level_comments) = self.parse_json(json)?;
-        let mut node = self.convert_node(&prism_ast)?;
+        let (prism_ast, top_level_comments) = Self::parse_json(json)?;
+        let mut node = Self::convert_node(&prism_ast)?;
 
         // Attach top-level comments to the root node
         if !top_level_comments.is_empty() {
             node.comments
-                .extend(top_level_comments.iter().map(|c| self.convert_comment(c)));
+                .extend(top_level_comments.iter().map(Self::convert_comment));
         }
 
         Ok(node)


### PR DESCRIPTION
## Summary

- Remove unused `&self` from `parse_json`, `convert_node`, `convert_comment`
- Merge duplicate match arms in comment type conversion
- Add backticks to type names in doc comments

Closes #50

🤖 Generated with [Claude Code](https://claude.ai/code)