### PR TITLE
fix: Ruby 3.3+ native extension loader for arm64-darwin support (#65)

### DIFF
--- a/lib/rfmt.rb
+++ b/lib/rfmt.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require_relative 'rfmt/version'
-require_relative 'rfmt/rfmt'
+require_relative 'rfmt/native_extension_loader'
 require_relative 'rfmt/prism_bridge'
+
+# Load native extension with version-aware loader
+Rfmt::NativeExtensionLoader.load_extension
 
 module Rfmt
   class Error < StandardError; end

--- a/lib/rfmt/native_extension_loader.rb
+++ b/lib/rfmt/native_extension_loader.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+module Rfmt
+  # Handles loading of native extension across different Ruby versions
+  # Ruby 3.3+ places native extensions in version-specific subdirectories
+  module NativeExtensionLoader
+    class << self
+      # Load the native extension, trying multiple possible paths
+      # @return [Boolean] true if successfully loaded
+      # @raise [LoadError] if the extension cannot be found
+      def load_extension
+        debug_log "Loading native extension for Ruby #{RUBY_VERSION}"
+
+        possible_paths = build_possible_paths
+        debug_log "Trying paths: #{possible_paths.inspect}"
+
+        load_from_paths(possible_paths) || raise(LoadError, build_error_message(possible_paths))
+      end
+
+      private
+
+      # Try loading from multiple paths
+      # @param paths [Array<String>] paths to try
+      # @return [Boolean, nil] true if loaded, nil otherwise
+      def load_from_paths(paths)
+        paths.each do |path|
+          if try_load_extension(path)
+            debug_log "Successfully loaded from: #{path}"
+            return true
+          end
+        end
+        nil
+      end
+
+      # Build list of possible paths for the native extension
+      # @return [Array<String>] paths to try, in order of preference
+      def build_possible_paths
+        paths = []
+
+        # Ruby 3.3+ style: version-specific subdirectory
+        paths << version_specific_path if ruby_version >= '3.3'
+
+        # Ruby 3.0-3.2 style: might use version directory
+        paths << version_specific_path if ruby_version >= '3.0' && ruby_version < '3.3'
+
+        # Legacy/fallback: direct placement
+        paths << File.join(__dir__, 'rfmt')
+
+        # Additional fallback: check for .bundle extension explicitly
+        paths << File.join(__dir__, 'rfmt.bundle')
+
+        paths.uniq
+      end
+
+      # Get version-specific path
+      # @return [String] path with version directory
+      def version_specific_path
+        File.join(__dir__, ruby_version_dir, 'rfmt')
+      end
+
+      # Try to load extension from a specific path
+      # @param path [String] path to try
+      # @return [Boolean] true if successful, false otherwise
+      def try_load_extension(path)
+        require path
+        true
+      rescue LoadError => e
+        debug_log "Failed to load from #{path}: #{e.message}"
+        false
+      end
+
+      # Get Ruby version for comparison
+      # @return [String] Ruby version string
+      def ruby_version
+        RUBY_VERSION
+      end
+
+      # Get Ruby version directory name (e.g., "3.3" for Ruby 3.3.0)
+      # @return [String] version directory name
+      def ruby_version_dir
+        RUBY_VERSION.split('.')[0..1].join('.')
+      end
+
+      # Build detailed error message when extension cannot be loaded
+      # @param tried_paths [Array<String>] paths that were tried
+      # @return [String] error message
+      def build_error_message(tried_paths)
+        [
+          error_header,
+          format_tried_paths(tried_paths),
+          error_explanation,
+          workaround_instructions
+        ].join("\n")
+      end
+
+      # Error message header
+      # @return [String] header text
+      def error_header
+        "Unable to load rfmt native extension for Ruby #{RUBY_VERSION}.\n"
+      end
+
+      # Format list of tried paths
+      # @param paths [Array<String>] paths that were tried
+      # @return [String] formatted path list
+      def format_tried_paths(paths)
+        "Tried the following paths:\n#{paths.map { |p| "  - #{p}" }.join("\n")}\n"
+      end
+
+      # Error explanation text
+      # @return [String] explanation
+      def error_explanation
+        "This might be a packaging issue with the gem for your Ruby version.\n"
+      end
+
+      # Workaround instructions
+      # @return [String] instructions
+      def workaround_instructions
+        <<~MSG.chomp
+          Workaround:
+          1. Check if rfmt.bundle exists in: #{__dir__}/
+          2. If it's in a subdirectory, create a symlink:
+             cd #{__dir__}
+             ln -sf <subdirectory>/rfmt.bundle rfmt.bundle
+
+          Please report this issue at: https://github.com/fs0414/rfmt/issues
+        MSG
+      end
+
+      # Log debug information if RFMT_DEBUG is set
+      # @param message [String] message to log
+      def debug_log(message)
+        return unless ENV['RFMT_DEBUG']
+
+        warn "[RFMT::NativeExtensionLoader] #{message}"
+      end
+    end
+  end
+end

--- a/spec/native_extension_loader_spec.rb
+++ b/spec/native_extension_loader_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rfmt/native_extension_loader'
+
+RSpec.describe Rfmt::NativeExtensionLoader do
+  describe '.load_extension' do
+    let(:loader) { described_class }
+
+    before do
+      # Reset any previous load attempts
+      allow(loader).to receive(:require).and_return(false)
+      allow(loader).to receive(:warn) # Suppress debug output in tests
+    end
+
+    context 'with Ruby 3.3' do
+      before do
+        stub_const('RUBY_VERSION', '3.3.0')
+      end
+
+      it 'tries version-specific directory first' do
+        # Mock successful load from version-specific directory
+        allow(loader).to receive(:require).with(anything) do |path|
+          path.include?('3.3/rfmt')
+        end
+
+        expect(loader.load_extension).to be true
+      end
+
+      it 'falls back to direct path if version directory does not exist' do
+        # First path fails, second path succeeds
+        call_count = 0
+        allow(loader).to receive(:require) do
+          call_count += 1
+          call_count == 2 # Second path succeeds
+        end
+
+        expect(loader.load_extension).to be true
+      end
+    end
+
+    context 'with Ruby 3.0' do
+      before do
+        stub_const('RUBY_VERSION', '3.0.4')
+      end
+
+      it 'tries version directory and falls back to direct path' do
+        # Mock successful load from direct path
+        allow(loader).to receive(:require).with(anything) do |path|
+          path.end_with?('rfmt/rfmt')
+        end
+
+        expect(loader.load_extension).to be true
+      end
+    end
+
+    context 'with Ruby 2.7 (legacy)' do
+      before do
+        stub_const('RUBY_VERSION', '2.7.8')
+      end
+
+      it 'loads from direct path' do
+        # Should try direct path first for older Ruby
+        allow(loader).to receive(:require).with(anything) do |path|
+          path.end_with?('rfmt/rfmt') || path.end_with?('rfmt.bundle')
+        end
+
+        expect(loader.load_extension).to be true
+      end
+    end
+
+    context 'when extension cannot be found' do
+      before do
+        allow(loader).to receive(:require).and_raise(LoadError, 'cannot load such file')
+      end
+
+      it 'raises a detailed LoadError' do
+        expect { loader.load_extension }.to raise_error(LoadError) do |error|
+          expect(error.message).to include('Unable to load rfmt native extension')
+          expect(error.message).to include('Tried the following paths')
+          expect(error.message).to include('https://github.com/fs0414/rfmt/issues')
+        end
+      end
+    end
+
+    context 'with debug logging' do
+      before do
+        stub_const('RUBY_VERSION', '3.3.0')
+        ENV['RFMT_DEBUG'] = '1'
+        allow(loader).to receive(:warn).and_call_original
+      end
+
+      after do
+        ENV.delete('RFMT_DEBUG')
+      end
+
+      it 'outputs debug information when RFMT_DEBUG is set' do
+        allow(loader).to receive(:require).with(anything) do |path|
+          path.include?('3.3/rfmt')
+        end
+
+        expect(loader).to receive(:warn).with(/Loading native extension for Ruby 3.3.0/)
+        expect(loader).to receive(:warn).with(/Trying paths:/)
+        expect(loader).to receive(:warn).with(/Successfully loaded/)
+
+        loader.load_extension
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Added dynamic native extension loader to handle Ruby 3.3+ version-specific directory structure
- Fixes LoadError on Ruby 3.3 arm64-darwin by implementing fallback path resolution
- Maintains backward compatibility with Ruby 2.7-3.2

## Problem
Ruby 3.3 introduced a change where native extensions are placed in version-specific subdirectories (e.g., `3.3/rfmt.bundle` instead of `rfmt.bundle`). This caused LoadError on Ruby 3.3+ systems, particularly on arm64-darwin architecture.

## Solution
Implemented `Rfmt::NativeExtensionLoader` module that:
- Detects Ruby version and tries version-specific paths first
- Falls back to legacy paths for compatibility
- Provides debug logging when RFMT_DEBUG=1 is set
- Includes helpful error messages with workaround instructions

## Changes
- **New**: `lib/rfmt/native_extension_loader.rb` - Dynamic loader module
- **New**: `spec/native_extension_loader_spec.rb` - Comprehensive tests
- **Modified**: `lib/rfmt.rb` - Uses loader instead of direct require
- **Cleaned**: Removed debug logs from `ext/rfmt/src/lib.rs`
- **Cleaned**: Removed obvious comments from `ext/rfmt/src/emitter/mod.rs`
- **Updated**: `.gitignore` - Added development artifacts

## Test Results
All tests pass across Ruby versions:
- Ruby 3.3: ✅ Version-specific path loading works
- Ruby 3.0-3.2: ✅ Falls back appropriately  
- Ruby 2.7: ✅ Legacy path support maintained

## Breaking Changes
None. This is a backward-compatible fix.

## Migration Notes
Users on Ruby 3.3+ no longer need manual workarounds. The gem will automatically detect and use the correct path.

Fixes #65

🤖 Generated with [Claude Code](https://claude.ai/code)