### PR TITLE
Fix rescue/ensure clauses being deleted in do...end blocks

### DIFF
--- a/ext/rfmt/src/emitter/mod.rs
+++ b/ext/rfmt/src/emitter/mod.rs
@@ -1193,14 +1193,27 @@ impl Emitter {
         let mut last_stmt_end_line = block_start_line;
 
         for child in &block_node.children {
-            if matches!(child.node_type, NodeType::StatementsNode) {
-                self.emit_statements(child, indent_level + 1)?;
-                // Track the last statement's end line for blank line preservation
-                if let Some(last_child) = child.children.last() {
-                    last_stmt_end_line = last_child.location.end_line;
+            match &child.node_type {
+                NodeType::StatementsNode => {
+                    self.emit_statements(child, indent_level + 1)?;
+                    // Track the last statement's end line for blank line preservation
+                    if let Some(last_child) = child.children.last() {
+                        last_stmt_end_line = last_child.location.end_line;
+                    }
+                    self.buffer.push('\n');
+                    break;
                 }
-                self.buffer.push('\n');
-                break;
+                NodeType::BeginNode => {
+                    // Block with rescue/ensure/else - delegate to emit_begin
+                    // which handles implicit begin (no "begin" keyword)
+                    self.emit_begin(child, indent_level + 1)?;
+                    self.buffer.push('\n');
+                    last_stmt_end_line = child.location.end_line;
+                    break;
+                }
+                _ => {
+                    // Skip parameter nodes
+                }
             }
         }
 

--- a/lib/rfmt/prism_bridge.rb
+++ b/lib/rfmt/prism_bridge.rb
@@ -176,6 +176,7 @@ module Rfmt
                      [
                        node.statements,
                        node.rescue_clause,
+                       node.else_clause,
                        node.ensure_clause
                      ].compact
                    when Prism::EnsureNode

--- a/spec/block_rescue_formatting_spec.rb
+++ b/spec/block_rescue_formatting_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Rfmt, 'Block with Rescue Formatting' do
+  describe 'do...end block with rescue' do
+    it 'preserves block body and rescue clause' do
+      source = <<~RUBY
+        foo.each do |x|
+          x
+        rescue StandardError => e
+          e
+        end
+      RUBY
+      result = Rfmt.format(source)
+      expect(result).to include('x')
+      expect(result).to include('rescue StandardError => e')
+    end
+
+    it 'formats block with multiple rescue clauses' do
+      source = <<~RUBY
+        data.map do |d|
+          transform(d)
+        rescue TypeError => e
+          handle_type_error(e)
+        rescue StandardError => e
+          handle_standard_error(e)
+        end
+      RUBY
+      result = Rfmt.format(source)
+      expect(result).to include('rescue TypeError')
+      expect(result).to include('rescue StandardError')
+    end
+
+    it 'formats block with rescue and else' do
+      source = <<~RUBY
+        items.each do |item|
+          process(item)
+        rescue => e
+          handle_error(e)
+        else
+          success
+        end
+      RUBY
+      result = Rfmt.format(source)
+      expect(result).to include('else')
+      expect(result).to include('success')
+    end
+
+    it 'formats block with rescue, else, and ensure' do
+      source = <<~RUBY
+        file.each_line do |line|
+          parse(line)
+        rescue ParseError => e
+          log_error(e)
+        else
+          mark_success
+        ensure
+          cleanup
+        end
+      RUBY
+      result = Rfmt.format(source)
+      expect(result).to include('rescue ParseError')
+      expect(result).to include('else')
+      expect(result).to include('ensure')
+    end
+
+    it 'formats block with only ensure' do
+      source = <<~RUBY
+        conn.transaction do |tx|
+          execute(tx)
+        ensure
+          tx.close
+        end
+      RUBY
+      result = Rfmt.format(source)
+      expect(result).to include('ensure')
+      expect(result).to include('tx.close')
+    end
+  end
+end


### PR DESCRIPTION
## 📋 Summary

Fix a bug where formatting a `do...end` block containing `rescue`/`ensure` clauses would incorrectly delete the block body and rescue/ensure clauses.

**Issue:** #73 - Block body and rescue clause lines are deleted

### Before (Bug)
```ruby
# Input
foo.each do |x|
  x
rescue StandardError => e
  e
end

# Output (bug)
foo.each do |x|
end
```

### After (Fixed)
```ruby
# Input
foo.each do |x|
  x
rescue StandardError => e
  e
end

# Output (correct)
foo.each do |x|
  x
rescue StandardError => e
  e
end
```

## 🔧 Changes

### 🐛 Bug Fix

- **`emit_do_end_block()`**: Added logic to detect `BeginNode` and delegate to existing `emit_begin()`
  - Prism parser returns `BeginNode` as the body for blocks with `rescue`/`ensure`
  - Previously only `StatementsNode` was processed, `BeginNode` was ignored

- **`prism_bridge.rb`**: Added `else_clause` to `BeginNode` children
  - Now handles `else` clause after `rescue` clause

### 🧪 Tests

- **5 new test cases**:
  - Basic `rescue` clause
  - Multiple `rescue` clauses
  - `rescue` + `else` clause
  - `rescue` + `else` + `ensure` clause
  - `ensure` clause only

## 🗂️ Changed Files

- **Rust emitter**: `ext/rfmt/src/emitter/mod.rs`
- **Ruby bridge**: `lib/rfmt/prism_bridge.rb`
- **Tests**: `spec/block_rescue_formatting_spec.rb` (new)

## 🧪 Testing

### Test Commands
```bash
bundle exec rspec spec/block_rescue_formatting_spec.rb
```

### Test Results
- 77 examples, 0 failures ✅

### Verification
- [x] Issue #73 reproduction case is fixed
- [x] Block with `rescue` clause formats correctly
- [x] Block with multiple `rescue` clauses formats correctly
- [x] Block with `rescue` + `else` formats correctly
- [x] Block with `rescue` + `else` + `ensure` formats correctly
- [x] Block with `ensure` only formats correctly
- [x] All existing tests pass (no regression)

## 📦 Breaking Changes
None

## Related Issue
Fixes #73

<a href="https://app.devin.ai/review/fs0414/rfmt/pull/78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
