### PR TITLE
Fix inline then style preservation for in/when/if expressions

### DIFF
--- a/spec/rfmt_spec.rb
+++ b/spec/rfmt_spec.rb
@@ -146,6 +146,56 @@ RSpec.describe Rfmt do
       expect(result).to include('42')
     end
 
+    describe 'inline then style preservation (Issue #75)' do
+      describe 'case...in with then' do
+        it 'preserves inline then style in pattern matching' do
+          source = <<~RUBY
+            case x
+              in ..0 then ['negative or zero']
+              in 1.. then ['positive']
+            end
+          RUBY
+          result = Rfmt.format(source)
+          expect(result).to include('then')
+          expect(Prism.parse(result).errors).to be_empty
+        end
+
+        it 'keeps multiline style when original has no then' do
+          source = <<~RUBY
+            case x
+            in ..0
+              ['negative']
+            end
+          RUBY
+          result = Rfmt.format(source)
+          expect(result).not_to include('then')
+        end
+      end
+
+      describe 'case...when with then' do
+        it 'preserves inline when then style' do
+          source = "case x; when 1 then 'one'; when 2 then 'two'; end\n"
+          result = Rfmt.format(source)
+          expect(result).to include('when 1 then')
+          expect(result).to include('when 2 then')
+        end
+      end
+
+      describe 'if/unless with then' do
+        it 'preserves inline if then style' do
+          source = "if true then 1 end\n"
+          result = Rfmt.format(source)
+          expect(result).to include('if true then 1 end')
+        end
+
+        it 'preserves inline unless then style' do
+          source = "unless false then 1 end\n"
+          result = Rfmt.format(source)
+          expect(result).to include('unless false then 1 end')
+        end
+      end
+    end
+
     describe 'inline comments after blocks' do
       it 'preserves inline comments after inline brace blocks' do
         source = "b.each { p it } # c\n"


### PR DESCRIPTION
## 📋 Summary

Fixes the issue where inline `then` style expressions were being converted to multi-line format during formatting. This was particularly critical for pattern matching `in` clauses, where removing `then` without adding a newline causes syntax errors.

Related Issue: Closes #75

## 🔧 Changes

### Core Implementation
- **`emit_in`**: Added inline style detection to preserve `in X then Y` format
- **`emit_when`**: Added inline style detection to preserve `when X then Y` format  
- **`emit_if_unless`**: Added inline style detection to preserve `if X then Y end` format

### Refactoring (Helper Methods)
- **`is_single_line()`**: New helper to check if a node spans a single line
- **`write_source_text()`**: New helper to extract and write source text
- **`write_source_text_trimmed()`**: New helper to extract and write trimmed source text

These helpers reduce code duplication across multiple emit functions.

## 🗂️ Changed Files
- **Emitter**: `ext/rfmt/src/emitter/mod.rs`
- **Tests**: `spec/rfmt_spec.rb`

## 🧪 Testing

### Test Commands
```bash
bundle exec rake compile
bundle exec rspec
```

### Test Results
- 84 examples, 0 failures

### Verification
- [x] `in ..0 then ['value']` preserves inline style
- [x] `when 1 then 'one'` preserves inline style
- [x] `if true then 1 end` preserves inline style
- [x] `unless false then 1 end` preserves inline style
- [x] Multi-line styles remain unchanged
- [x] Formatted output passes `ruby -c` syntax check

## 📦 Breaking Changes
None