### PR TITLE
Fix duplicate comment output when method chain has block

### DIFF
--- a/ext/rfmt/src/emitter/mod.rs
+++ b/ext/rfmt/src/emitter/mod.rs
@@ -1196,6 +1196,16 @@ impl Emitter {
             if let Some(text) = self.source.get(start..end) {
                 // Trim trailing whitespace but preserve the content
                 write!(self.buffer, "{}", text.trim_end())?;
+
+                // Mark comments within the extracted range as emitted
+                for (idx, comment) in self.all_comments.iter().enumerate() {
+                    if !self.emitted_comment_indices.contains(&idx)
+                        && comment.location.start_offset >= start
+                        && comment.location.end_offset <= end
+                    {
+                        self.emitted_comment_indices.insert(idx);
+                    }
+                }
             }
         }
 

--- a/spec/rfmt_spec.rb
+++ b/spec/rfmt_spec.rb
@@ -253,6 +253,33 @@ RSpec.describe Rfmt do
         source = "[1, 2].map { |x| x * 2 } # double\n"
         expect(Rfmt.format(source)).to eq("[1, 2].map { |x| x * 2 } # double\n")
       end
+
+      it 'does not duplicate inline comments on method chain with block' do
+        source = <<~RUBY
+          some_method # comment
+            .method_with_block { do_something }
+        RUBY
+
+        result = Rfmt.format(source)
+
+        # The comment should appear exactly once, not be duplicated
+        expect(result.scan('# comment').count).to eq(1)
+        expect(result).to eq(source)
+      end
+
+      it 'does not duplicate inline comments on method chain with do-end block' do
+        source = <<~RUBY
+          some_method # comment
+            .method_with_block do
+              do_something
+            end
+        RUBY
+
+        result = Rfmt.format(source)
+
+        # The comment should appear exactly once
+        expect(result.scan('# comment').count).to eq(1)
+      end
     end
   end
 


### PR DESCRIPTION
## 📋 Summary

Fixes a bug where inline comments were duplicated in the output when formatting code with chained method calls that include blocks.

**Before (bug):**
```ruby
# Input
some_method # comment
  .method_with_block { do_something }

# Output (incorrect - comment duplicated)
some_method # comment
  .method_with_block { do_something }
# comment  ← duplicated
```

**After (fixed):**
```ruby
# Input = Output (no change, already formatted)
some_method # comment
  .method_with_block { do_something }
```

## 🔧 Changes

### Core Fix
- **`emit_call_without_block()`**: Added logic to mark comments within the extracted source range as emitted, preventing duplicate output in subsequent processing

### Root Cause
When `emit_call_without_block()` extracts source text from `call_node.start_offset` to `block_node.start_offset`, inline comments are included in the extracted text. However, these comments were not being marked in `emitted_comment_indices`, causing them to be output again by later comment-handling routines.

### Test Coverage
- Added 2 test cases covering:
  - Method chain with brace block (`{ }`)
  - Method chain with do-end block

## 🗂️ Changed Files
- **Rust emitter**: `ext/rfmt/src/emitter/mod.rs`
- **Tests**: `spec/rfmt_spec.rb`

## 🧪 Testing

### Test Execution
```bash
bundle exec rspec
```

### Results
- 89 examples, 0 failures
- No regressions

### Verification
- [x] Bug reproduction confirmed before fix
- [x] New tests pass after fix
- [x] All existing tests pass (regression check)
- [x] Manual verification with `rfmt --diff`

## 📦 Breaking Changes
None

## Related Issue
Closes #85