### PR TITLE
Fix Prism comment JSON deserialization (comment_type / embdoc)

### DIFF
--- a/.claude/plans/abstract-kindling-mochi.md
+++ b/.claude/plans/abstract-kindling-mochi.md
@@ -1,0 +1,70 @@
+# Issue #87: modifier if のインラインコメントが次の行に移動される
+
+## Context
+
+modifier if/unless（後置if）の行末に付いたインラインコメント（例: `# steep:ignore`）が、フォーマット後に次の行へ移動されてしまうバグ。`# steep:ignore` のようなツールディレクティブは対象行に留まる必要があるため、コメント位置の変更はセマンティクスの破壊につながる。
+
+**入力**: `some_method if condition # steep:ignore`
+**期待**: そのまま保持
+**実際**: コメントが次の行に分離される
+
+## 原因
+
+`ext/rfmt/src/emitter/mod.rs` の `emit_if_unless` 関数内、postfix if パス（行985-1004）で `return Ok(())` する前に `emit_trailing_comments` を呼んでいない。
+
+同じ行のコメントが未出力のまま残り、後続処理で standalone コメントとして次の行に出力される。
+
+ternary operator パス（行1013-1039）にも同じ問題がある。
+
+**比較:**
+- postfix if（行1003）: `return Ok(());` ← `emit_trailing_comments` なし
+- ternary（行1038）: `return Ok(());` ← `emit_trailing_comments` なし
+- inline then（行1064）: `self.emit_trailing_comments(...)` あり ← 正常
+
+## 修正
+
+### 1. postfix if パスに `emit_trailing_comments` を追加
+
+**ファイル**: `ext/rfmt/src/emitter/mod.rs` 行1002付近
+
+`return Ok(());` の直前に追加:
+```rust
+self.emit_trailing_comments(node.location.end_line)?;
+return Ok(());
+```
+
+### 2. ternary operator パスにも同様に追加
+
+**ファイル**: `ext/rfmt/src/emitter/mod.rs` 行1037付近
+
+`return Ok(());` の直前に追加:
+```rust
+self.emit_trailing_comments(node.location.end_line)?;
+return Ok(());
+```
+
+### 3. テスト追加
+
+**ファイル**: `spec/conditional_formatting_spec.rb`（既存の postfix if テストの後に追加）
+
+```ruby
+it 'preserves inline comments on postfix if' do
+  source = "some_method if condition # steep:ignore\n"
+  result = Rfmt.format(source)
+  expect(result).to eq("some_method if condition # steep:ignore\n")
+end
+
+it 'preserves inline comments on postfix unless' do
+  source = "some_method unless condition # steep:ignore\n"
+  result = Rfmt.format(source)
+  expect(result).to eq("some_method unless condition # steep:ignore\n")
+end
+```
+
+## 検証
+
+```bash
+bundle exec rake compile
+bundle exec rspec
+bundle exec rspec spec/conditional_formatting_spec.rb
+```

--- a/.claude/plans/adaptive-honking-bengio.md
+++ b/.claude/plans/adaptive-honking-bengio.md
@@ -1,0 +1,75 @@
+# Nix開発環境の改善: ビルド高速化 + zsh対応 + ログ整理
+
+## Context
+
+現在の `flake.nix` には3つの課題がある:
+1. **ビルドが遅い**: devShellのevaluation cache がなく、パッケージビルドでは毎回Cargo依存のダウンロードが発生する
+2. **zshが使えない**: `nix develop` はデフォルトでbashを起動し、ローカルの `~/.zshrc` 設定が引き継がれない
+3. **ログが煩雑**: 絵文字が多用されており、ターミナル出力がクリーンでない
+
+## 変更対象ファイル
+
+- `flake.nix` (主要な変更)
+- `.envrc` (新規作成)
+
+## 変更内容
+
+### 1. ビルド高速化
+
+#### devShell (最大の効果)
+- `.envrc` に `use flake` を追加し、direnv + nix-direnvで**devShellのevaluationをキャッシュ**する
+- これにより、flakeが変更されない限りdevShell起動がほぼ即時になる
+- zshのまま環境変数が注入されるため、シェル切替のオーバーヘッドもなくなる
+
+#### パッケージビルド
+- `fetchCargoVendor` でCargo依存をNix storeに事前キャッシュし、ビルド時のネットワークアクセスを排除する
+- mkDerivation内で `.cargo/config.toml` のvendoring設定を自動生成する
+
+> **正直な制約**: rb-sysのビルドパイプラインではcraneが使えないため、Rustコンパイル自体は毎回実行される。これはNixサンドボックスの性質上避けられない。ネットワーク部分のキャッシュが主な改善点となる。
+
+### 2. zsh対応 (direnvで解決)
+
+- `.envrc` を作成してgitにコミットする（`.gitignore`で除外されていないことは確認済み）
+- direnvはシェル自体を変更せず、環境変数を現在のシェル（zsh）に注入するだけなので、`~/.zshrc` の設定がそのまま維持される
+- shellHookのPROMPT設定部分を簡素化（direnv経由の場合はプロンプト変更をスキップ）
+
+### 3. 絵文字除去 + ログ整理
+
+flake.nix内の全絵文字メッセージをプレーンテキストに置換:
+
+| 変更前 | 変更後 |
+|--------|--------|
+| `"🚀 rfmt dev env ready \| ..."` | `"rfmt dev env ready \| ..."` |
+| `"🔧 Setting up..."` | `"Setting up rfmt development environment..."` |
+| `"❌ Nix is not installed..."` | `"Error: Nix is not installed..."` |
+| `"⚠️  direnv not found..."` | `"Warning: direnv not found. Installing..."` |
+| `"✅ Creating .envrc..."` | `"Creating .envrc file..."` |
+| `"✅ Setup complete!..."` | `"Setup complete."` |
+| `"🧪 Running rfmt tests..."` | `"Running rfmt tests..."` |
+| `"📦 Installing dependencies..."` | `"Installing dependencies..."` |
+| `"🔨 Compiling extension..."` | `"Compiling extension..."` |
+| `"🧪 Running Ruby tests..."` | `"Running Ruby tests..."` |
+| `"🦀 Running Rust tests..."` | `"Running Rust tests..."` |
+| `"✅ All tests passed!"` | `"All tests passed."` |
+
+エラーは `Error:` 、警告は `Warning:` のプレフィックスで統一。
+
+## 実装順序
+
+1. 絵文字除去（単純な文字列置換）
+2. shellHookの簡素化 + direnv対応
+3. `.envrc` の作成
+4. `fetchCargoVendor` の導入（ビルド試行でhash計算が必要）
+
+## 検証方法
+
+1. `nix flake check` でNix構文エラーがないことを確認
+2. `nix develop --command echo ok` でdevShellが動作することを確認
+3. `direnv allow && direnv reload` でzsh上で環境が注入されることを確認
+4. flake.nix内に絵文字が残っていないことをgrepで確認
+
+## 注意事項
+
+- `fetchCargoVendor` のhash値は初回ビルド時にエラーから取得する必要がある
+- `nix-direnv` がインストール済みであることが前提（素のdirenvだと毎回evalが走り遅い）
+- ext/rfmt/Cargo.lock が `.gitignore` で除外されているため、`fetchCargoVendor` の `src` 指定に注意が必要

--- a/.claude/plans/issue-71-btreemap-range-error.md
+++ b/.claude/plans/issue-71-btreemap-range-error.md
@@ -1,0 +1,132 @@
+# Issue #71 修正計画: BTreeMap範囲エラー（Endless Method + Comment）
+
+## 1. 問題の原因特定
+
+### 1.1 問題の所在
+- **ファイルパス**: `ext/rfmt/src/emitter/mod.rs`
+- **問題箇所1**: `get_comment_indices_in_range()` (L146-152)
+- **問題箇所2**: `emit_comments_before_end()` (L257)
+- **問題箇所3**: `has_comments_in_range()` (L230-238)
+
+### 1.2 根本原因
+**分類**: ロジックエラー（境界条件の考慮不足）
+
+**原因**:
+- `def a = nil`（endless method）は単一行で`start_line == end_line`
+- `emit_comments_before_end()`で`(start_line + 1)..end_line`という範囲を作成
+- endless methodの場合`4..3`のような無効な範囲になる
+- `BTreeMap.range()`は`start > end`でパニック
+
+**トリガー条件**:
+```ruby
+class Test
+  # comment
+  def a = nil  # endless method
+end
+```
+
+### 1.3 問題パターンと学び
+
+**パターン**: "Range Boundary Error" - 境界値を考慮しない範囲生成
+
+**根本的な誤解**:
+- 誤解: `start_line + 1`は常に`end_line`以下である
+- 正解: endless methodでは`start_line == end_line`なので無効になる
+
+---
+
+## 2. 解決策
+
+### 2.1 修正方針
+`get_comment_indices_in_range()`と`has_comments_in_range()`に範囲チェックを追加し、`start_line >= end_line`の場合は早期リターンする。
+
+### 2.2 変更差分
+
+**ファイル**: `ext/rfmt/src/emitter/mod.rs`
+
+```diff
+# get_comment_indices_in_range() (L146-152)
+fn get_comment_indices_in_range(&self, start_line: usize, end_line: usize) -> Vec<usize> {
++   // Guard against invalid range (e.g., endless methods where start_line >= end_line)
++   if start_line >= end_line {
++       return Vec::new();
++   }
+    self.comments_by_line
+        .range(start_line..end_line)
+        .flat_map(|(_, indices)| indices.iter().copied())
+        .filter(|&idx| !self.emitted_comment_indices.contains(&idx))
+        .collect()
+}
+```
+
+```diff
+# has_comments_in_range() (L230-238)
+fn has_comments_in_range(&self, start_line: usize, end_line: usize) -> bool {
++   // Guard against invalid range (e.g., endless methods where start_line >= end_line)
++   if start_line >= end_line {
++       return false;
++   }
+    self.comments_by_line
+        .range(start_line..end_line)
+        .flat_map(|(_, indices)| indices.iter())
+        .any(|&idx| {
+            !self.emitted_comment_indices.contains(&idx)
+                && self.all_comments[idx].location.end_line < end_line
+        })
+}
+```
+
+### 2.3 なぜこの修正で解決するか
+
+- **技術的根拠**: 無効な範囲`4..3`がBTreeMapに渡される前にチェックされる
+- **Before**: `range(4..3)` → パニック
+- **After**: `4 >= 3`で早期リターン → 空の結果を返す（endless methodにはボディ内コメントがない）
+
+### 2.4 影響分析
+- **破壊的変更**: なし
+- **パフォーマンス**: 変化なし（早期リターンでむしろ微改善）
+- **影響モジュール**: emitter/mod.rs のみ
+- **下位互換性**: 保たれる
+
+---
+
+## 3. 修正計画
+
+### Phase 1: 修正実装
+1. `get_comment_indices_in_range()`に範囲チェック追加
+2. `has_comments_in_range()`に範囲チェック追加
+
+### Phase 2: テスト追加
+1. `spec/rfmt_spec.rb`にendless method + commentのテスト追加
+2. 再現コードでの動作確認
+
+### Phase 3: 検証
+1. `bundle exec rspec`で全テスト実行
+2. 再現コードでのフォーマット確認
+
+---
+
+## 4. 修正対象ファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `ext/rfmt/src/emitter/mod.rs` | 2箇所に範囲チェック追加 |
+| `spec/rfmt_spec.rb` | endless method + commentのテスト追加 |
+
+---
+
+## 5. 検証方法
+
+```bash
+# テスト用ファイル作成
+echo 'class Test
+  # comment
+  def a = nil
+end' > /tmp/test_endless.rb
+
+# フォーマット実行（エラーが出ないことを確認）
+bundle exec rfmt /tmp/test_endless.rb
+
+# RSpecテスト実行
+bundle exec rspec
+```

--- a/.claude/plans/issue-85-comment-duplication.md
+++ b/.claude/plans/issue-85-comment-duplication.md
@@ -1,0 +1,128 @@
+# Issue #85: チェインメソッド＋ブロック時のコメント重複バグ修正
+
+## 問題の概要
+
+**入力コード:**
+```ruby
+some_method # comment
+  .method_with_block { do_something }
+```
+
+**期待される出力:** 変更なし（既にフォーマット済み）
+
+**実際の出力:**
+```ruby
+some_method # comment
+  .method_with_block { do_something }
+# comment  ← 重複して追加される
+```
+
+---
+
+## 根本原因
+
+### コード箇所
+`ext/rfmt/src/emitter/mod.rs`
+
+### 問題のメカニズム
+
+1. **`emit_call()`** (L1134-1164) がブロック付きメソッドチェーンを処理
+2. **`emit_call_without_block()`** (L1184-1202) がソースから `call_node.start_offset` ～ `block_node.start_offset` を抽出
+   - この時、`# comment` は抽出テキストに**含まれている**
+   - しかし `emitted_comment_indices` に**登録されない**
+3. **`emit_brace_block()`** (L1276-1312) でブロック処理後に `emit_trailing_comments(block_end_line)` を呼び出し
+   - `block_end_line` = 2（ブロック終了行）
+   - コメントは行1にあるため、ここでは出力されない（問題なし）
+
+4. **真の問題箇所**: `emit_call()` が完了した後、親ノードの処理で再度 `emit_trailing_comments()` が呼ばれる可能性
+   - または、`emit_statements()` などで末尾コメント処理が行われる
+
+### 問題の本質
+`emit_call_without_block()` でソーステキストを抽出した際、そのテキストに含まれるインラインコメントを `emitted_comment_indices` にマークしていないため、後続の処理で同じコメントが再出力される。
+
+---
+
+## 修正方針
+
+### 修正箇所
+`emit_call_without_block()` 関数 (L1184-1202)
+
+### 修正内容
+ソーステキスト抽出後、その範囲内に含まれるコメントを `emitted_comment_indices` にマークする処理を追加。
+
+```rust
+fn emit_call_without_block(
+    &mut self,
+    call_node: &Node,
+    block_node: &Node,
+    indent_level: usize,
+) -> Result<()> {
+    self.emit_indent(indent_level)?;
+
+    if !self.source.is_empty() {
+        let start = call_node.location.start_offset;
+        let end = block_node.location.start_offset;
+
+        if let Some(text) = self.source.get(start..end) {
+            write!(self.buffer, "{}", text.trim_end())?;
+
+            // ★追加: 抽出範囲内のコメントを emitted としてマーク
+            let call_start_line = call_node.location.start_line;
+            let block_start_line = block_node.location.start_line;
+
+            for (idx, comment) in self.all_comments.iter().enumerate() {
+                if !self.emitted_comment_indices.contains(&idx)
+                    && comment.location.start_line >= call_start_line
+                    && comment.location.start_line < block_start_line
+                {
+                    self.emitted_comment_indices.insert(idx);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+```
+
+---
+
+## 実装タスク
+
+1. [ ] `emit_call_without_block()` にコメントマーキング処理を追加
+2. [ ] テストケースを追加
+   - インラインコメント + ブレースブロック
+   - インラインコメント + do-endブロック
+   - 複数行チェーン + コメント
+3. [ ] 既存テストが通ることを確認
+
+---
+
+## 検証方法
+
+### 再現テスト
+```bash
+# テストファイル作成
+echo 'some_method # comment
+  .method_with_block { do_something }' > /tmp/test_comment.rb
+
+# フォーマット実行（--diffで差分確認）
+bundle exec rfmt /tmp/test_comment.rb --diff
+
+# 期待: 差分なし
+```
+
+### ユニットテスト実行
+```bash
+bundle exec rspec
+```
+
+---
+
+## 関連ファイル
+
+- `ext/rfmt/src/emitter/mod.rs` - 主な修正対象
+  - `emit_call()`: L1134-1164
+  - `emit_call_without_block()`: L1184-1202（修正箇所）
+  - `emit_trailing_comments()`: L427-440
+  - `emit_brace_block()`: L1276-1312

--- a/.claude/plans/issue86-heredoc-fix.md
+++ b/.claude/plans/issue86-heredoc-fix.md
@@ -1,0 +1,221 @@
+# Issue #86 修正計画 - t-wada TDDアプローチ
+
+## バグ概要
+
+**Issue**: [#86](https://github.com/fs0414/rfmt/issues/86) - Heredocコンテンツと終了識別子が誤って削除される
+
+**現象**: メソッド呼び出しの引数として複数のHeredocを使用すると、本体と終了識別子が削除される
+
+```ruby
+# 入力
+puts(<<~HEREDOC, <<~HEREDOC2)
+  This is a heredoc.
+HEREDOC
+  This is another heredoc.
+HEREDOC2
+
+# 現在の出力（バグ）
+puts(<<~HEREDOC, <<~HEREDOC2)
+# ← Heredoc内容が全て削除される
+```
+
+**根本原因**: `lib/rfmt/prism_bridge.rb`の`extract_location`メソッドが直接の子ノードのみをチェックしている。CallNodeの場合、Heredocは`ArgumentsNode`を介した孫ノードにあるため検出されない。
+
+---
+
+## TDDサイクル
+
+### Phase 1: Red（失敗テスト作成）
+
+**ファイル**: `spec/rfmt_spec.rb` (行185の後に追加)
+
+```ruby
+describe 'heredoc in method call arguments (Issue #86)' do
+  it 'preserves multiple heredocs as method arguments' do
+    source = <<~RUBY
+      puts(<<~HEREDOC, <<~HEREDOC2)
+        This is a heredoc.
+      HEREDOC
+        This is another heredoc.
+      HEREDOC2
+    RUBY
+    result = Rfmt.format(source)
+
+    expect(result).to include('This is a heredoc.')
+    expect(result).to include('This is another heredoc.')
+    expect(result).to match(/^HEREDOC$/m)
+    expect(result).to match(/^HEREDOC2$/m)
+    expect(Prism.parse(result).errors).to be_empty
+  end
+
+  it 'preserves single heredoc as method argument' do
+    source = <<~RUBY
+      puts(<<~HEREDOC)
+        Single heredoc content.
+      HEREDOC
+    RUBY
+    result = Rfmt.format(source)
+
+    expect(result).to include('Single heredoc content.')
+    expect(result).to match(/^HEREDOC$/m)
+    expect(Prism.parse(result).errors).to be_empty
+  end
+
+  it 'preserves heredoc with method chain' do
+    source = <<~RUBY
+      foo.bar(<<~SQL)
+        SELECT * FROM users
+      SQL
+    RUBY
+    result = Rfmt.format(source)
+
+    expect(result).to include('SELECT * FROM users')
+    expect(result).to match(/^SQL$/m)
+    expect(Prism.parse(result).errors).to be_empty
+  end
+
+  it 'preserves heredoc with block' do
+    source = <<~RUBY
+      process(<<~DATA) do |result|
+        content here
+      DATA
+        puts result
+      end
+    RUBY
+    result = Rfmt.format(source)
+
+    expect(result).to include('content here')
+    expect(result).to match(/^DATA$/m)
+    expect(Prism.parse(result).errors).to be_empty
+  end
+end
+```
+
+**検証**: `bundle exec rspec spec/rfmt_spec.rb -e "Issue #86"` → 全テスト失敗を確認
+
+---
+
+### Phase 2: Green（最小実装）
+
+**ファイル**: `lib/rfmt/prism_bridge.rb`
+
+**修正内容**: `extract_location`メソッドに再帰的な`closing_loc`検索を追加
+
+```ruby
+# Extract location information from node
+def self.extract_location(node)
+  loc = node.location
+
+  end_offset = loc.end_offset
+  end_line = loc.end_line
+  end_column = loc.end_column
+
+  # Check this node's closing_loc
+  if node.respond_to?(:closing_loc) && node.closing_loc
+    closing = node.closing_loc
+    if closing.end_offset > end_offset
+      end_offset = closing.end_offset
+      end_line = closing.end_line
+      end_column = closing.end_column
+    end
+  end
+
+  # Recursively check all descendant nodes for heredoc closing_loc
+  # Issue #86: Handles CallNode -> ArgumentsNode -> StringNode (heredoc)
+  max_closing = find_max_closing_loc_recursive(node)
+  if max_closing && max_closing[:end_offset] > end_offset
+    end_offset = max_closing[:end_offset]
+    end_line = max_closing[:end_line]
+    end_column = max_closing[:end_column]
+  end
+
+  {
+    start_line: loc.start_line,
+    start_column: loc.start_column,
+    end_line: end_line,
+    end_column: end_column,
+    start_offset: loc.start_offset,
+    end_offset: end_offset
+  }
+end
+
+# Recursively find the maximum closing_loc among all descendant nodes
+# Returns nil if no closing_loc found, otherwise { end_offset:, end_line:, end_column: }
+def self.find_max_closing_loc_recursive(node, depth: 0)
+  return nil if depth > 10 # Prevent infinite recursion
+
+  max_closing = nil
+
+  node.child_nodes.compact.each do |child|
+    # Check if this child has a closing_loc (heredoc)
+    if child.respond_to?(:closing_loc) && child.closing_loc
+      closing = child.closing_loc
+      if max_closing.nil? || closing.end_offset > max_closing[:end_offset]
+        max_closing = {
+          end_offset: closing.end_offset,
+          end_line: closing.end_line,
+          end_column: closing.end_column
+        }
+      end
+    end
+
+    # Recursively check grandchildren
+    child_max = find_max_closing_loc_recursive(child, depth: depth + 1)
+    if child_max && (max_closing.nil? || child_max[:end_offset] > max_closing[:end_offset])
+      max_closing = child_max
+    end
+  end
+
+  max_closing
+end
+```
+
+**検証**: `bundle exec rspec spec/rfmt_spec.rb -e "Issue #86"` → 全テストパス
+
+---
+
+### Phase 3: Refactor
+
+1. 既存の直接子ノードチェック（行128-138）を削除し、再帰メソッドに統一
+2. コメント追加（Issue #74と#86の参照）
+3. 全回帰テスト実行
+
+---
+
+## 検証手順
+
+```bash
+# 1. 失敗テスト確認（Red）
+bundle exec rspec spec/rfmt_spec.rb -e "Issue #86" --format documentation
+
+# 2. 実装後のテスト確認（Green）
+bundle exec rspec spec/rfmt_spec.rb -e "Issue #86" --format documentation
+
+# 3. 回帰テスト（既存機能の確認）
+bundle exec rspec
+
+# 4. 手動検証
+echo 'puts(<<~HEREDOC, <<~HEREDOC2)
+  This is a heredoc.
+HEREDOC
+  This is another heredoc.
+HEREDOC2' > /tmp/test.rb
+bundle exec rfmt /tmp/test.rb --diff
+```
+
+---
+
+## 修正対象ファイル
+
+| ファイル | 変更内容 |
+|----------|----------|
+| `spec/rfmt_spec.rb` | Issue #86 失敗テスト追加（行185後） |
+| `lib/rfmt/prism_bridge.rb` | `extract_location`に再帰検索追加、`find_max_closing_loc_recursive`メソッド追加 |
+
+---
+
+## 実装順序
+
+1. **Red**: `spec/rfmt_spec.rb`にテスト追加 → 失敗確認
+2. **Green**: `lib/rfmt/prism_bridge.rb`に再帰メソッド実装 → テストパス
+3. **Refactor**: コード整理、全テスト実行

--- a/.claude/plans/keen-booping-book.md
+++ b/.claude/plans/keen-booping-book.md
@@ -1,0 +1,264 @@
+# Issue #73: BlockNode内のrescue句でコードが削除されるバグの修正
+
+## 問題概要
+
+`rescue`句を含む`do...end`ブロックをフォーマットすると、ブロック本体とrescue句が削除される。
+
+```ruby
+# 入力
+foo.each do |x|
+  x
+rescue StandardError => e
+  e
+end
+
+# 現在の出力（バグ）
+foo.each do |x|
+end
+```
+
+## 根本原因
+
+### 調査結果: BlockNodeのbodyに来る可能性のあるノードタイプ
+
+| ノードタイプ | 条件 | 発生するブロック形式 |
+|------------|------|-------------------|
+| `StatementsNode` | 通常のブロック | `do...end`, `{ }` |
+| `BeginNode` | rescue/ensure/else付き | `do...end`のみ |
+| `nil` | 空のブロック | 両方 |
+
+**重要**: `{ }`ブロックでは`rescue`/`ensure`は**構文エラー**になるため、`BeginNode`は来ない。
+
+### BeginNodeの構造（rescue/ensure/else付きブロック）
+
+```
+BlockNode
+└── body: BeginNode
+    ├── statements: StatementsNode (ブロック本体)
+    ├── rescue_clause: RescueNode (オプション)
+    ├── else_clause: ElseNode (オプション、rescueの後)
+    └── ensure_clause: EnsureNode (オプション)
+```
+
+### 問題箇所
+
+| ファイル | 問題 |
+|---------|------|
+| `ext/rfmt/src/emitter/mod.rs` | `emit_do_end_block`が`BeginNode`を無視 |
+| `lib/rfmt/prism_bridge.rb` | `BeginNode`で`else_clause`が欠落 |
+
+## TDDサイクル実装計画
+
+### Phase 1: Red - 失敗するテストを作成
+
+**新規ファイル**: `spec/block_rescue_formatting_spec.rb`
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Rfmt, 'Block with Rescue Formatting' do
+  describe 'do...end block with rescue' do
+    it 'preserves block body and rescue clause' do
+      source = <<~RUBY
+        foo.each do |x|
+          x
+        rescue StandardError => e
+          e
+        end
+      RUBY
+      result = Rfmt.format(source)
+      expect(result).to include('x')
+      expect(result).to include('rescue StandardError => e')
+    end
+
+    it 'formats block with multiple rescue clauses' do
+      source = <<~RUBY
+        data.map do |d|
+          transform(d)
+        rescue TypeError => e
+          handle_type_error(e)
+        rescue StandardError => e
+          handle_standard_error(e)
+        end
+      RUBY
+      result = Rfmt.format(source)
+      expect(result).to include('rescue TypeError')
+      expect(result).to include('rescue StandardError')
+    end
+
+    it 'formats block with rescue and else' do
+      source = <<~RUBY
+        items.each do |item|
+          process(item)
+        rescue => e
+          handle_error(e)
+        else
+          success
+        end
+      RUBY
+      result = Rfmt.format(source)
+      expect(result).to include('else')
+      expect(result).to include('success')
+    end
+
+    it 'formats block with rescue, else, and ensure' do
+      source = <<~RUBY
+        file.each_line do |line|
+          parse(line)
+        rescue ParseError => e
+          log_error(e)
+        else
+          mark_success
+        ensure
+          cleanup
+        end
+      RUBY
+      result = Rfmt.format(source)
+      expect(result).to include('rescue ParseError')
+      expect(result).to include('else')
+      expect(result).to include('ensure')
+    end
+
+    it 'formats block with only ensure' do
+      source = <<~RUBY
+        conn.transaction do |tx|
+          execute(tx)
+        ensure
+          tx.close
+        end
+      RUBY
+      result = Rfmt.format(source)
+      expect(result).to include('ensure')
+      expect(result).to include('tx.close')
+    end
+  end
+end
+```
+
+### Phase 2: Green - 最小限の修正
+
+#### 修正1: Ruby側 (`lib/rfmt/prism_bridge.rb`)
+
+`BeginNode`の子ノードに`else_clause`を追加：
+
+```ruby
+when Prism::BeginNode
+  [
+    node.statements,
+    node.rescue_clause,
+    node.else_clause,      # 追加
+    node.ensure_clause
+  ].compact
+```
+
+#### 修正2: Rust側 (`ext/rfmt/src/emitter/mod.rs`)
+
+`emit_do_end_block`関数を修正して`BeginNode`を処理：
+
+```rust
+fn emit_do_end_block(&mut self, block_node: &Node, indent_level: usize) -> Result<()> {
+    write!(self.buffer, " do")?;
+    self.emit_block_parameters(block_node)?;
+    self.emit_trailing_comments(block_node.location.start_line)?;
+    self.buffer.push('\n');
+
+    let block_start_line = block_node.location.start_line;
+    let block_end_line = block_node.location.end_line;
+    let mut last_stmt_end_line = block_start_line;
+
+    for child in &block_node.children {
+        match &child.node_type {
+            NodeType::StatementsNode => {
+                self.emit_statements(child, indent_level + 1)?;
+                if let Some(last_child) = child.children.last() {
+                    last_stmt_end_line = last_child.location.end_line;
+                }
+                self.buffer.push('\n');
+                break;
+            }
+            NodeType::BeginNode => {
+                // rescue/ensure/else付きブロック本体
+                // emit_beginの暗黙的begin処理を利用
+                self.emit_begin(child, indent_level + 1)?;
+                last_stmt_end_line = child.location.end_line;
+                break;
+            }
+            _ => {
+                // パラメータノードはスキップ
+            }
+        }
+    }
+
+    // コメント処理とend出力（既存コードと同じ）
+    let had_internal_comments =
+        self.has_comments_in_range(block_start_line + 1, block_end_line);
+    if had_internal_comments {
+        self.emit_comments_in_range_with_prev_line(
+            block_start_line + 1,
+            block_end_line,
+            indent_level + 1,
+            last_stmt_end_line,
+        )?;
+    }
+
+    if had_internal_comments && !self.buffer.ends_with('\n') {
+        self.buffer.push('\n');
+    }
+
+    self.emit_indent(indent_level)?;
+    write!(self.buffer, "end")?;
+    self.emit_trailing_comments(block_end_line)?;
+
+    Ok(())
+}
+```
+
+### Phase 3: Refactor
+
+- 既存の`emit_begin`の暗黙的begin処理を活用
+- 改行・インデントの調整が必要な場合は微調整
+
+## 修正対象ファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `spec/block_rescue_formatting_spec.rb` | 新規作成 - 失敗テスト |
+| `lib/rfmt/prism_bridge.rb` | `BeginNode`に`else_clause`追加 |
+| `ext/rfmt/src/emitter/mod.rs` | `emit_do_end_block`で`BeginNode`処理 |
+
+## 検証手順
+
+```bash
+# 1. 新規テスト実行（最初は失敗）
+bundle exec rspec spec/block_rescue_formatting_spec.rb
+
+# 2. Ruby側修正後、Rust拡張ビルド
+bundle exec rake compile
+
+# 3. 新規テスト実行（通過確認）
+bundle exec rspec spec/block_rescue_formatting_spec.rb
+
+# 4. 全テスト実行（回帰確認）
+bundle exec rspec
+
+# 5. 手動確認
+cat <<'EOF' | bundle exec rfmt
+foo.each do |x|
+  x
+rescue StandardError => e
+  e
+else
+  success
+ensure
+  cleanup
+end
+EOF
+```
+
+## 注意点
+
+- `emit_begin`の暗黙的begin処理では`emit_node`が呼ばれ、各ノードタイプ用のemit関数が呼び出される
+- `emit_rescue`と`emit_ensure`は`indent_level.saturating_sub(1)`でインデントを調整する
+- ブロック内の場合、`emit_begin`に渡すインデントレベルは`indent_level + 1`とする

--- a/.claude/plans/learn-format-flow.md
+++ b/.claude/plans/learn-format-flow.md
@@ -1,0 +1,262 @@
+# rfmt formatフローの理解（プリントデバッグ学習）
+
+## 目的
+
+rfmtのformat処理の全体フローを、プリントデバッグを通じて手を動かしながら理解する。
+
+## サンプルコード
+
+学習全体を通して、以下のシンプルなRubyコードをフォーマット対象として使用する：
+
+```ruby
+def hello( name )
+if name
+puts "Hello, #{name}!"
+end
+end
+```
+
+---
+
+## フロー概要図
+
+```
+exe/rfmt
+  ↓
+Rfmt::CLI.start(args)
+  ↓
+Rfmt.format(source)
+  ├─ PrismBridge.parse(source)     ← Ruby側: ソース → AST JSON
+  └─ format_code(source, json)     ← Rust側: AST JSON → フォーマット済みコード
+      ├─ PrismAdapter::parse(json)   → Rust内部AST
+      ├─ Config::discover()          → 設定読み込み
+      └─ Emitter::emit(ast)          → コード生成
+```
+
+---
+
+## ビルドシステムと動作確認方法
+
+### プロジェクト構成
+
+rfmtは **Ruby + Rust ハイブリッド** のgemプロジェクト。
+
+```
+rfmt/
+├── exe/rfmt                  ← CLIエントリーポイント（Rubyスクリプト）
+├── lib/                      ← Ruby側コード
+│   └── rfmt/
+│       ├── rfmt.bundle       ← コンパイル済みRust拡張（.so/.dylib）
+│       ├── cli.rb            ← Thor CLIフレームワーク
+│       ├── prism_bridge.rb   ← Prism パーサー統合
+│       └── ...
+├── ext/rfmt/                 ← Rust側コード
+│   ├── Cargo.toml            ← Rust依存関係
+│   └── src/
+│       ├── lib.rs            ← Magnus FFIエントリーポイント
+│       ├── emitter/mod.rs    ← コード生成（最大モジュール）
+│       ├── parser/           ← JSON→AST変換
+│       └── ...
+├── Rakefile                  ← ビルド・テストタスク定義
+├── Gemfile                   ← Ruby依存関係
+└── rfmt.gemspec
+```
+
+### 主要な依存関係
+
+| ライブラリ | 言語 | 役割 |
+|-----------|------|------|
+| **Prism** | Ruby | Ruby公式パーサー。ソースコード → AST |
+| **Magnus** | Rust | Rust ↔ Ruby FFIバインディング |
+| **RbSys** | Ruby/Rust | Rustネイティブ拡張のビルドシステム |
+| **Thor** | Ruby | CLIフレームワーク |
+| **serde_json** | Rust | JSONシリアライズ/デシリアライズ |
+
+### ビルドコマンド
+
+```bash
+# Rust拡張のコンパイル（Ruby側の変更には不要）
+bundle exec rake compile
+
+# 全テスト実行（Ruby + Rust）
+bundle exec rake dev:test_all
+
+# Rubyテストのみ
+bundle exec rspec
+
+# Rustテストのみ
+bundle exec rake dev:test_rust
+
+# ビルド成果物のクリーン
+bundle exec rake dev:clean
+```
+
+### 動作確認方法
+
+```bash
+# 方法1: ファイルを指定してformat（--no-write で上書きしない）
+bundle exec rfmt format --no-write sample.rb
+
+# 方法2: Rubyワンライナーで直接呼ぶ（デバッグ時に便利）
+echo 'def hello; end' | bundle exec ruby -e "require 'rfmt'; puts Rfmt.format(STDIN.read)"
+
+# 方法3: IRBで対話的に試す
+bundle exec rake console
+# irb> Rfmt.format("def hello; end")
+
+# 方法4: checkモード（差分確認のみ、ファイル変更なし）
+bundle exec rfmt check sample.rb
+```
+
+### デバッグ時のワークフロー
+
+```
+┌─────────────────────────────────────────────┐
+│  Ruby側 を変更した場合                        │
+│  → そのまま実行可能（再コンパイル不要）          │
+├─────────────────────────────────────────────┤
+│  Rust側 を変更した場合                        │
+│  → bundle exec rake compile が必要            │
+│  → lib/rfmt/rfmt.bundle が再生成される        │
+├─────────────────────────────────────────────┤
+│  デバッグ出力の使い分け                        │
+│  Ruby側: $stderr.puts "DEBUG: ..."           │
+│  Rust側: eprintln!("DEBUG: ...")              │
+│  → どちらもstderrに出るため、stdoutの結果と    │
+│    混ざらない                                 │
+└─────────────────────────────────────────────┘
+```
+
+### 環境変数
+
+| 変数 | 効果 |
+|------|------|
+| `DEBUG=1` | エラー時にバックトレース表示 |
+| `RFMT_VERBOSE=1` | Ruby警告を表示 |
+
+---
+
+## Phase一覧
+
+| Phase | 内容 | ファイル | 状態 |
+|-------|------|----------|------|
+| 1 | エントリーポイントの追跡（CLI → format呼び出し） | `exe/rfmt`, `lib/rfmt.rb` | ⬜ 未着手 |
+| 2 | Prismパース結果の確認（Ruby → AST JSON） | `lib/rfmt/prism_bridge.rb` | ⬜ 未着手 |
+| 3 | Rust側への橋渡し（JSON → Rust内部AST） | `ext/rfmt/src/lib.rs`, `parser/prism_adapter.rs` | ⬜ 未着手 |
+| 4 | Emitterの動作確認（AST → コード生成の全体） | `ext/rfmt/src/emitter/mod.rs` | ⬜ 未着手 |
+| 5 | 特定ノードのemit追跡（if/defなど具体的ノード） | `ext/rfmt/src/emitter/mod.rs` | ⬜ 未着手 |
+
+---
+
+## Phase 1: エントリーポイントの追跡
+
+**目的**: CLIから`Rfmt.format(source)`が呼ばれるまでの流れを確認する
+
+**デバッグ方法**: Ruby側に`puts`を追加
+
+**対象ファイル**:
+- `exe/rfmt` - コマンド起動
+- `lib/rfmt/cli.rb` - CLIコマンド処理
+- `lib/rfmt.rb` - `Rfmt.format()`メソッド
+
+**確認ポイント**:
+- [ ] CLIでどのサブコマンドが選択されるか
+- [ ] ファイル一覧がどう解決されるか
+- [ ] `Rfmt.format(source)`に渡されるソースの内容
+
+**学んだこと**:
+（Phase完了後に記録）
+
+---
+
+## Phase 2: Prismパース結果の確認
+
+**目的**: Rubyソースコードがどのような構造のAST JSONに変換されるか確認する
+
+**デバッグ方法**: `PrismBridge.parse()`内に`puts`/`pp`を追加
+
+**対象ファイル**:
+- `lib/rfmt/prism_bridge.rb` - パース処理とJSON変換
+
+**確認ポイント**:
+- [ ] `Prism.parse()`の結果オブジェクトの構造
+- [ ] `convert_node()`がどのようにノードを再帰変換するか
+- [ ] 最終的なJSON文字列の構造（特にnode_type、children、metadata）
+- [ ] コメント情報がどう収集されるか
+
+**学んだこと**:
+（Phase完了後に記録）
+
+---
+
+## Phase 3: Rust側への橋渡し
+
+**目的**: Ruby側で生成されたJSON文字列がRust側でどのようにパースされ内部ASTに変換されるか確認する
+
+**デバッグ方法**: Rust側に`eprintln!`マクロを追加 → `bundle exec rake compile` → 実行
+
+**対象ファイル**:
+- `ext/rfmt/src/lib.rs` - Rustエントリーポイント
+- `ext/rfmt/src/parser/prism_adapter.rs` - JSONパース・AST変換
+
+**確認ポイント**:
+- [ ] `format_ruby_code()`に渡される引数
+- [ ] `PrismAdapter::parse()`でJSON→Rust構造体への変換
+- [ ] Rust側の`Node`構造体の中身
+
+**学んだこと**:
+（Phase完了後に記録）
+
+---
+
+## Phase 4: Emitterの動作確認
+
+**目的**: ASTからフォーマット済みコードが生成される全体像を確認する
+
+**デバッグ方法**: `eprintln!`でEmitterの各ステップを追跡
+
+**対象ファイル**:
+- `ext/rfmt/src/emitter/mod.rs` - コード生成ロジック
+
+**確認ポイント**:
+- [ ] `emit()`メソッドの全体的な流れ
+- [ ] コメント収集とインデックス構築
+- [ ] `emit_node()`のディスパッチ（どのノードが何の関数に振り分けられるか）
+- [ ] bufferにどのタイミングで何が書き込まれるか
+
+**学んだこと**:
+（Phase完了後に記録）
+
+---
+
+## Phase 5: 特定ノードのemit追跡
+
+**目的**: 具体的なノード（def、if、文字列補間など）のemit処理を詳しく追跡する
+
+**デバッグ方法**: 各emit_*メソッドに`eprintln!`を追加
+
+**対象ファイル**:
+- `ext/rfmt/src/emitter/mod.rs`
+
+**確認ポイント**:
+- [ ] `emit_method()`（def文）の処理フロー
+- [ ] `emit_if_unless()`（if文）の処理フロー
+- [ ] インデントレベルの管理方法
+- [ ] ソースコードの部分抽出（offsetの使い方）
+
+**学んだこと**:
+（Phase完了後に記録）
+
+---
+
+## 完了条件
+
+- [ ] サンプルRubyコードの「パース → AST変換 → emit」の各段階で、中間データを自分の目で確認できた
+- [ ] 各Phaseの「学んだこと」セクションが記入されている
+- [ ] フォーマットフロー全体を自分の言葉で説明できる
+
+## 注意事項
+
+- デバッグ用の`puts`/`eprintln!`は学習後に必ず削除する
+- Rust側を変更した場合は`bundle exec rake compile`が必要
+- デバッグ出力は`stderr`（`eprintln!`）を使うとformatの出力と混ざらない

--- a/.claude/plans/proud-marinating-hearth.md
+++ b/.claude/plans/proud-marinating-hearth.md
@@ -1,0 +1,354 @@
+# PBT 探索的パターン管理の実装プラン
+
+## Context
+
+PBT は **未知のバグを探索するための道具** であり、既知ケースの防御は E2E テストが担う。
+現状の `spec/pbt_rails_format_spec.rb`(632行)は単一ファイルで全パターンが混在し、
+「どの領域を探索済みか」「発見した問題は何か」が管理できない。
+
+**目的**: パターン空間をグループ化して探索を計画的に進められるようにし、
+発見したバグを E2E テストへスムーズに引き渡せる仕組みを作る。
+
+## 設計思想
+
+```
+探索 PBT の役割:
+  ┌────────────┐     発見     ┌────────────┐     移管     ┌────────────┐
+  │ PBT 探索   │ ──────────▶ │ discoveries/ │ ──────────▶ │ E2E テスト │
+  │ (ランダム) │             │ (一時保存)   │             │ (永続防御) │
+  └────────────┘             └────────────┘             └────────────┘
+       ↑
+  カバレッジマップで未探索領域を特定
+```
+
+- PBT で見つかったバグ → `discoveries/` に一時保存 → E2E テスト作成後に削除
+- PBT 自体にはデグレーションテストを持たない
+- カバレッジマップで探索の偏りを可視化
+
+## ファイル構成
+
+```
+spec/
+├── support/
+│   └── pbt/
+│       ├── catalog.rb              # パターンカタログ (登録 + カバレッジマップ)
+│       ├── primitives.rb           # 共通プリミティブジェネレータ
+│       ├── properties.rb           # 4プロパティの検証ロジック
+│       ├── discovery_reporter.rb   # バグ発見時のファイル保存 + コンソール出力
+│       └── generators/
+│           ├── controller.rb
+│           ├── model.rb
+│           ├── migration.rb
+│           ├── concern.rb
+│           ├── job.rb
+│           ├── mailer.rb
+│           ├── serializer.rb
+│           ├── route.rb
+│           ├── service.rb
+│           └── config.rb
+├── fixtures/
+│   └── pbt/
+│       ├── coverage.yml            # カバレッジマップ (探索履歴)
+│       └── discoveries/            # 発見されたバグの一時保存 (E2E移管後に削除)
+│           └── .gitkeep
+├── pbt_rails_format_spec.rb        # メインテスト (カタログから動的生成)
+└── spec_helper.rb                  # support/ 読み込み追加
+```
+
+## Step 1: パターンカタログ + カバレッジマップ
+
+**ファイル**: `spec/support/pbt/catalog.rb`
+
+パターンの登録と探索履歴の追跡を担う中心モジュール。
+
+```ruby
+module PBT
+  PatternEntry = Data.define(:name, :group, :tags, :generator)
+
+  module Catalog
+    @entries = []
+
+    # パターン登録
+    def self.register(name:, group:, tags: [], &generator)
+      @entries << PatternEntry.new(name:, group:, tags:, generator:)
+    end
+
+    # 検索
+    def self.all = @entries
+    def self.by_group(group) = @entries.select { |e| e.group == group }
+    def self.by_tag(tag) = @entries.select { |e| e.tags.include?(tag) }
+    def self.groups = @entries.map(&:group).uniq.sort
+
+    # カバレッジマップ更新 (テスト実行後に呼ばれる)
+    def self.record_run(group:, runs:, failures:)
+      coverage = load_coverage
+      key = group.to_s
+      coverage[key] ||= { 'total_runs' => 0, 'total_failures' => 0, 'sessions' => [] }
+      coverage[key]['total_runs'] += runs
+      coverage[key]['total_failures'] += failures
+      coverage[key]['sessions'] << {
+        'date' => Time.now.strftime('%Y-%m-%d %H:%M'),
+        'runs' => runs,
+        'failures' => failures
+      }
+      save_coverage(coverage)
+    end
+
+    # カバレッジレポート出力
+    def self.coverage_report
+      coverage = load_coverage
+      groups.each do |g|
+        data = coverage[g.to_s]
+        if data
+          puts "  #{g}: #{data['total_runs']} runs, #{data['total_failures']} failures, last: #{data['sessions'].last&.dig('date') || 'never'}"
+        else
+          puts "  #{g}: ** UNEXPLORED **"
+        end
+      end
+    end
+  end
+end
+```
+
+**カバレッジマップ (`coverage.yml`)** の例:
+```yaml
+controller:
+  total_runs: 1500
+  total_failures: 0
+  sessions:
+    - { date: "2026-02-23 14:30", runs: 500, failures: 0 }
+    - { date: "2026-02-24 10:00", runs: 1000, failures: 0 }
+model:
+  total_runs: 500
+  total_failures: 1
+  sessions:
+    - { date: "2026-02-23 14:30", runs: 500, failures: 1 }
+```
+
+## Step 2: ジェネレータ分割
+
+**ファイル**: `spec/support/pbt/primitives.rb` + `spec/support/pbt/generators/*.rb`
+
+現在の `pbt_rails_format_spec.rb` からジェネレータを抽出。
+
+`primitives.rb`: 共通メソッド (`gen_class_name`, `gen_method_name` 等) を `PBT::Primitives` モジュールに集約。
+
+各 `generators/*.rb`: カテゴリ別にクラスを定義し、Catalog に登録。
+
+```ruby
+# spec/support/pbt/generators/controller.rb
+module PBT
+  module Generators
+    class Controller
+      include PBT::Primitives
+
+      def generate
+        # 現在の gen_controller の内容
+      end
+    end
+  end
+end
+
+PBT::Catalog.register(name: :controller, group: :controller, tags: [:rails_dsl]) {
+  PBT::Generators::Controller.new.generate
+}
+```
+
+**tags の設計** (パターンの性質を示すラベル):
+- `:rails_dsl` — Rails DSL を使うパターン (controller, model, concern, job, mailer)
+- `:data_def` — データ定義系 (migration, serializer)
+- `:routing` — ルーティング系 (route)
+- `:plain_ruby` — 純粋な Ruby コード (service, config)
+- `:edge_case` — エッジケース (将来追加: deep_nesting, long_chain, heredoc 等)
+
+## Step 3: プロパティ検証モジュール
+
+**ファイル**: `spec/support/pbt/properties.rb`
+
+4プロパティのチェックロジックを再利用可能なモジュールに。
+
+```ruby
+module PBT
+  module Properties
+    module_function
+
+    def check_idempotent(source)
+      once = Rfmt.format(source)
+      twice = Rfmt.format(once)
+      { pass: once == twice, once: once, twice: twice }
+    end
+
+    def check_syntax_preservation(source)
+      formatted = Rfmt.format(source)
+      errors = Prism.parse(formatted).errors
+      { pass: errors.empty?, formatted: formatted, errors: errors }
+    end
+
+    def check_no_crash(source)
+      Rfmt.format(source)
+      { pass: true }
+    rescue Rfmt::Error
+      { pass: true }  # 構文エラーは許容
+    rescue => e
+      { pass: false, error: e }
+    end
+
+    def check_content_preservation(source, identifiers)
+      formatted = Rfmt.format(source)
+      missing = identifiers.reject { |id| formatted.include?(id) }
+      { pass: missing.empty?, formatted: formatted, missing: missing }
+    end
+  end
+end
+```
+
+## Step 4: DiscoveryReporter
+
+**ファイル**: `spec/support/pbt/discovery_reporter.rb`
+
+バグ発見時にコンソール詳細出力 + ファイル自動保存を行う。
+
+```ruby
+module PBT
+  module DiscoveryReporter
+    DISCOVERIES_DIR = File.expand_path('../../fixtures/pbt/discoveries', __dir__)
+
+    module_function
+
+    def report(group:, property:, source:, detail:)
+      timestamp = Time.now.strftime('%Y%m%d_%H%M%S')
+      id = "#{group}_#{property}_#{timestamp}"
+      filepath = File.join(DISCOVERIES_DIR, "#{id}.yml")
+
+      data = {
+        'id' => id,
+        'group' => group.to_s,
+        'property' => property.to_s,
+        'discovered' => Time.now.iso8601,
+        'migrated_to_e2e' => false,
+        'source' => source,
+        'detail' => detail
+      }
+
+      File.write(filepath, data.to_yaml)
+
+      # コンソール出力
+      warn "\n#{'=' * 60}"
+      warn "PBT DISCOVERY: #{id}"
+      warn "Group: #{group}, Property: #{property}"
+      warn "Source:\n#{source}"
+      warn "Detail: #{detail}"
+      warn "Saved to: #{filepath}"
+      warn "#{'=' * 60}\n"
+    end
+  end
+end
+```
+
+## Step 5: メインテストファイルのリファクタリング
+
+**ファイル**: `spec/pbt_rails_format_spec.rb`
+
+Catalog から動的にテスト生成。RSpec タグでフィルタリング可能。
+テスト完了後にカバレッジマップを自動更新。
+
+```ruby
+require 'spec_helper'
+require 'prism'
+
+NUM_RUNS = Integer(ENV.fetch('RAILS_FMT_PBT_RUNS', 100))
+
+RSpec.describe 'PBT: Rails formatting' do
+  PBT::Catalog.groups.each do |group|
+    entries = PBT::Catalog.by_group(group)
+    group_tags = entries.flat_map(&:tags).uniq.map { |t| [t, true] }.to_h
+
+    describe group.to_s, **group_tags, group => true do
+      entries.each do |entry|
+        failure_count = 0
+
+        it "FP1: idempotent (#{entry.name})" do
+          NUM_RUNS.times { |i|
+            source = entry.generator.call
+            next if Prism.parse(source).errors.any?
+            result = PBT::Properties.check_idempotent(source)
+            unless result[:pass]
+              failure_count += 1
+              PBT::DiscoveryReporter.report(
+                group: group, property: :idempotent,
+                source: source, detail: PBT::Properties.diff(result[:once], result[:twice])
+              )
+            end
+            expect(result[:pass]).to be(true), "Idempotency failed (run #{i+1})"
+          }
+        end
+
+        # FP2, FP3, FP4 も同様のパターン ...
+
+        after(:all) do
+          PBT::Catalog.record_run(group: group, runs: NUM_RUNS, failures: failure_count)
+        end
+      end
+    end
+  end
+end
+```
+
+## Step 6: spec_helper.rb の更新
+
+`spec/support/pbt/` の自動読み込みを追加:
+
+```ruby
+Dir[File.join(__dir__, 'support', 'pbt', '**', '*.rb')].sort.each { |f| require f }
+```
+
+## 実行コマンド
+
+```bash
+# 全探索
+bundle exec rspec spec/pbt_rails_format_spec.rb
+
+# カテゴリ指定
+bundle exec rspec spec/pbt_rails_format_spec.rb --tag controller
+bundle exec rspec spec/pbt_rails_format_spec.rb --tag model
+
+# タグ指定 (性質ベース)
+bundle exec rspec spec/pbt_rails_format_spec.rb --tag rails_dsl
+bundle exec rspec spec/pbt_rails_format_spec.rb --tag edge_case
+
+# 回数指定
+RAILS_FMT_PBT_RUNS=500 bundle exec rspec spec/pbt_rails_format_spec.rb --tag controller
+
+# カバレッジマップ表示
+bundle exec ruby -e "require_relative 'spec/support/pbt/catalog'; PBT::Catalog.coverage_report"
+```
+
+## 実装順序
+
+1. `spec/support/pbt/catalog.rb` — カタログ + カバレッジマップ
+2. `spec/support/pbt/primitives.rb` — 共通ジェネレータ抽出
+3. `spec/support/pbt/properties.rb` — プロパティ検証モジュール
+4. `spec/support/pbt/discovery_reporter.rb` — 発見レポーター
+5. `spec/support/pbt/generators/*.rb` — 10カテゴリのジェネレータ分割・登録
+6. `spec/fixtures/pbt/coverage.yml` — 空の初期カバレッジ
+7. `spec/fixtures/pbt/discoveries/.gitkeep` — 発見ディレクトリ
+8. `spec/pbt_rails_format_spec.rb` — カタログベースに書き換え
+9. `spec/spec_helper.rb` — support/ 読み込み追加
+10. 全テスト実行で動作確認
+
+## 検証方法
+
+```bash
+# 1. 全 PBT テストが PASS すること
+RAILS_FMT_PBT_RUNS=100 bundle exec rspec spec/pbt_rails_format_spec.rb --format documentation
+
+# 2. タグフィルタリングが動作すること
+bundle exec rspec spec/pbt_rails_format_spec.rb --tag controller --format documentation
+bundle exec rspec spec/pbt_rails_format_spec.rb --tag rails_dsl --format documentation
+
+# 3. カバレッジマップが更新されること
+cat spec/fixtures/pbt/coverage.yml
+
+# 4. 既存テストが壊れていないこと
+bundle exec rspec spec/ --exclude-pattern 'spec/pbt_*'
+```

--- a/.claude/plans/spicy-booping-hoare.md
+++ b/.claude/plans/spicy-booping-hoare.md
@@ -1,0 +1,93 @@
+# VSCode format on save 動作確認 & テスト充実化
+
+## Context
+
+rfmtにはRuby LSP Addon（`lib/ruby_lsp/rfmt/`）によるformat on save機能が既に実装されているが、動作確認が不十分で、テストも最小限の状態。ruby-lsp 0.26.4のインターフェースと照合した結果、**未実装の必須メソッドが2つ**見つかった。これらを修正し、テストを充実させることで、format on saveの信頼性を確保する。
+
+## 発見された問題
+
+### 1. `version` メソッド未実装（addon.rb）
+- `RubyLsp::Addon` 基底クラスで `version` は abstract method（呼び出されると `AbstractMethodInvokedError` が発生）
+- ruby-lsp がアドオンのバージョン互換性チェック時に呼び出す
+- **参照**: `.nix-gem-home/gems/ruby-lsp-0.26.4/lib/ruby_lsp/addon.rb:222-225`
+
+### 2. `run_range_formatting` メソッド未実装（formatter_runner.rb）
+- Formatter インターフェースで定義されている（`run_formatting`, `run_range_formatting`, `run_diagnostic` の3つ）
+- 範囲フォーマット（選択範囲のみフォーマット）で使用される
+- **参照**: `.nix-gem-home/gems/ruby-lsp-0.26.4/lib/ruby_lsp/requests/support/formatter.rb:18`
+
+## 実装計画
+
+### Step 1: `addon.rb` に `version` メソッドを追加
+
+**ファイル**: `lib/ruby_lsp/rfmt/addon.rb`
+
+```ruby
+def version
+  ::Rfmt::VERSION
+end
+```
+
+既存の `Rfmt::VERSION`（`lib/rfmt/version.rb`）を再利用する。
+
+### Step 2: `formatter_runner.rb` に `run_range_formatting` メソッドを追加
+
+**ファイル**: `lib/ruby_lsp/rfmt/formatter_runner.rb`
+
+```ruby
+def run_range_formatting(uri, source, base_indentation)
+  ::Rfmt.format(source)
+rescue ::Rfmt::Error
+  nil
+end
+```
+
+### Step 3: `formatter_runner_spec.rb` にテストケースを追加
+
+**ファイル**: `spec/ruby_lsp/rfmt/formatter_runner_spec.rb`
+
+追加するテストケース:
+
+| テスト | 目的 |
+|-------|------|
+| フォーマット結果の内容検証 | `be_a(String)` だけでなく、インデントが正しいか等を検証 |
+| べき等性（idempotency） | 2回フォーマットしても同じ結果になること（format on save は毎保存で実行されるため重要） |
+| 複数メソッドのクラス | 実用的なサイズのコードでの検証 |
+| 非Rfmt::Errorの例外が伝播すること | `rescue ::Rfmt::Error` のスコープが正しいことの確認 |
+| `run_range_formatting` の基本動作 | 新規追加メソッドのテスト |
+
+### Step 4: `addon_spec.rb` にテストケースを追加
+
+**ファイル**: `spec/ruby_lsp/rfmt/addon_spec.rb`
+
+追加するテストケース:
+- `version` が `Rfmt::VERSION` を返すこと
+
+### Step 5: スモークテストスクリプトの作成
+
+**ファイル**: `script/smoke_test_formatter.rb`
+
+ruby-lsp を起動せずに FormatterRunner を直接呼び出し、format on save と同等の処理パスを検証する簡易スクリプト。手動での動作確認やCI上でも実行可能。
+
+## 変更対象ファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `lib/ruby_lsp/rfmt/addon.rb` | `version` メソッド追加 |
+| `lib/ruby_lsp/rfmt/formatter_runner.rb` | `run_range_formatting` メソッド追加 |
+| `spec/ruby_lsp/rfmt/formatter_runner_spec.rb` | テストケース5件追加 |
+| `spec/ruby_lsp/rfmt/addon_spec.rb` | `version` テスト追加 |
+| `script/smoke_test_formatter.rb` | 新規作成（スモークテスト） |
+
+## 検証方法
+
+```bash
+# 1. 全テスト実行
+bundle exec rspec spec/ruby_lsp/
+
+# 2. スモークテスト実行
+bundle exec ruby script/smoke_test_formatter.rb
+
+# 3. 全体のテストスイートが壊れていないことを確認
+bundle exec rspec
+```

--- a/.claude/plans/streamed-spinning-peacock.md
+++ b/.claude/plans/streamed-spinning-peacock.md
@@ -1,0 +1,115 @@
+# Issue #87: ポストフィックスif/unlessのインラインコメントが次の行に移動するバグ修正
+
+## 問題概要
+
+```ruby
+# 入力
+some_method if condition # steep:ignore
+
+# 実際の出力（バグ）
+some_method if condition
+# steep:ignore
+
+# 期待される出力
+some_method if condition # steep:ignore
+```
+
+## 根本原因
+
+`ext/rfmt/src/emitter/mod.rs:1003` のポストフィックスif処理で `emit_trailing_comments()` が呼ばれずに `return Ok(())` している。
+
+他の形式（inline_then: L1064、通常if: L1087）では正しく呼ばれており、ポストフィックスifのみ欠落。
+
+## 修正計画（t-wada TDDサイクル）
+
+### Cycle 1: Red → Green（基本ケース）
+
+#### Red: 失敗テストを書く
+
+`spec/conditional_formatting_spec.rb` に追加:
+
+```ruby
+describe 'postfix if/unless with inline comments (Issue #87)' do
+  it 'preserves inline comment after postfix if' do
+    source = "some_method if condition # comment\n"
+    result = Rfmt.format(source)
+    expect(result).to eq("some_method if condition # comment\n")
+  end
+end
+```
+
+確認: `bundle exec rspec spec/conditional_formatting_spec.rb` → FAIL
+
+#### Green: 最小限の修正
+
+`ext/rfmt/src/emitter/mod.rs` L1003の `return Ok(());` の前に1行追加:
+
+```rust
+self.emit_trailing_comments(node.location.end_line)?;
+return Ok(());
+```
+
+確認: `bundle exec rake compile && bundle exec rspec spec/conditional_formatting_spec.rb` → PASS
+
+### Cycle 2: Red → Green（unless版）
+
+#### Red: unless版テスト追加
+
+```ruby
+it 'preserves inline comment after postfix unless' do
+  source = "some_method unless condition # comment\n"
+  result = Rfmt.format(source)
+  expect(result).to eq("some_method unless condition # comment\n")
+end
+```
+
+#### Green: Cycle 1の修正で既にPASSするはず（同じコードパスを通るため）
+
+### Cycle 3: Red → Green（実ユースケース steep:ignore）
+
+```ruby
+it 'preserves tool directive comment (steep:ignore) after postfix if' do
+  source = "some_method if condition # steep:ignore\n"
+  result = Rfmt.format(source)
+  expect(result).to eq("some_method if condition # steep:ignore\n")
+end
+```
+
+### Cycle 4: リグレッション防止テスト
+
+```ruby
+it 'preserves postfix if without comment (regression)' do
+  source = "some_method if condition\n"
+  result = Rfmt.format(source)
+  expect(result).to eq("some_method if condition\n")
+end
+
+it 'preserves postfix unless without comment (regression)' do
+  source = "some_method unless condition\n"
+  result = Rfmt.format(source)
+  expect(result).to eq("some_method unless condition\n")
+end
+```
+
+### Refactor
+
+修正が1行追加のみのため、リファクタリングは不要。
+
+### 全体リグレッション確認
+
+```bash
+bundle exec rspec
+```
+
+## 修正対象ファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `ext/rfmt/src/emitter/mod.rs` | L1003前に `emit_trailing_comments` 呼び出し追加（1行） |
+| `spec/conditional_formatting_spec.rb` | ポストフィックスif/unless + コメントのテスト追加（5ケース） |
+
+## 検証手順
+
+1. `bundle exec rake compile` — Rust拡張のビルド成功
+2. `bundle exec rspec spec/conditional_formatting_spec.rb` — 新規テスト全PASS
+3. `bundle exec rspec` — 全テストPASS（リグレッションなし）

--- a/.direnv/flake-profile
+++ b/.direnv/flake-profile
@@ -1,1 +1,0 @@
-flake-profile-1-link

--- a/.direnv/flake-profile-1-link
+++ b/.direnv/flake-profile-1-link
@@ -1,1 +1,0 @@
-/nix/store/jk0k7vnz23ag48gsc44b8pwaxqqnz0yq-nix-shell-env

--- a/ext/rfmt/src/parser/prism_adapter.rs
+++ b/ext/rfmt/src/parser/prism_adapter.rs
@@ -1,8 +1,9 @@
 use crate::ast::{Comment, CommentPosition, CommentType, FormattingInfo, Location, Node, NodeType};
 use crate::error::{Result, RfmtError};
 use crate::parser::RubyParser;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
+use std::fmt;
 
 /// Prism parser adapter
 /// This integrates with Ruby Prism parser via Magnus FFI
@@ -144,7 +145,13 @@ pub struct PrismLocation {
 pub struct PrismComment {
     pub text: String,
     pub location: PrismLocation,
-    #[serde(rename = "type", default)]
+    /// PrismBridge sends `comment_type`; older payloads may use `type`.
+    #[serde(
+        default,
+        rename = "comment_type",
+        alias = "type",
+        deserialize_with = "deserialize_prism_comment_type"
+    )]
     pub comment_type: PrismCommentType,
     #[serde(default)]
     pub position: PrismCommentPosition,
@@ -156,6 +163,37 @@ pub enum PrismCommentType {
     #[default]
     Line,
     Block,
+}
+
+/// Maps Ruby Prism comment class names (after `PrismBridge` normalization) to our enum.
+/// Unknown values default to `Line` so parsing never fails on new Prism comment kinds.
+fn deserialize_prism_comment_type<'de, D>(deserializer: D) -> std::result::Result<PrismCommentType, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de::{self, Visitor};
+
+    struct CommentTypeVisitor;
+
+    impl Visitor<'_> for CommentTypeVisitor {
+        type Value = PrismCommentType;
+
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            f.write_str("a Prism comment type string")
+        }
+
+        fn visit_str<E: de::Error>(self, v: &str) -> std::result::Result<Self::Value, E> {
+            Ok(match v {
+                // LineComment -> "line", InlineComment -> "inline"
+                "line" | "inline" => PrismCommentType::Line,
+                // EmbDocComment (=begin/=end) -> "embdoc"; keep "block" for compatibility
+                "block" | "embdoc" => PrismCommentType::Block,
+                _ => PrismCommentType::Line,
+            })
+        }
+    }
+
+    deserializer.deserialize_str(CommentTypeVisitor)
 }
 
 impl From<PrismCommentType> for CommentType {
@@ -199,6 +237,7 @@ pub struct PrismFormattingInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ast::CommentType;
 
     #[test]
     fn test_parse_simple_program() {
@@ -425,5 +464,119 @@ mod tests {
         );
         assert!(node.is_unknown());
         assert_eq!(node.unknown_type(), Some("totally_unknown_node"));
+    }
+
+    /// Ruby PrismBridge uses `comment_type` (not `type`) and values like `embdoc` / `inline`.
+    #[test]
+    fn test_parse_wrapper_with_prism_bridge_comment_fields() {
+        let adapter = PrismAdapter::new();
+        let json = r##"{
+            "ast": {
+                "node_type": "program_node",
+                "location": {
+                    "start_line": 1,
+                    "start_column": 0,
+                    "end_line": 2,
+                    "end_column": 0,
+                    "start_offset": 0,
+                    "end_offset": 20
+                },
+                "children": [],
+                "metadata": {},
+                "comments": [],
+                "formatting": {
+                    "indent_level": 0,
+                    "needs_blank_line_before": false,
+                    "needs_blank_line_after": false,
+                    "preserve_newlines": false,
+                    "multiline": false,
+                    "original_formatting": null
+                }
+            },
+            "comments": [
+                {
+                    "text": "=begin\nnote\n=end",
+                    "comment_type": "embdoc",
+                    "location": {
+                        "start_line": 1,
+                        "start_column": 0,
+                        "end_line": 3,
+                        "end_column": 4,
+                        "start_offset": 0,
+                        "end_offset": 16
+                    },
+                    "position": "leading"
+                },
+                {
+                    "text": "# inline style",
+                    "comment_type": "inline",
+                    "location": {
+                        "start_line": 4,
+                        "start_column": 0,
+                        "end_line": 4,
+                        "end_column": 14,
+                        "start_offset": 17,
+                        "end_offset": 31
+                    },
+                    "position": "leading"
+                }
+            ]
+        }"##;
+
+        let result = adapter.parse(json);
+        assert!(result.is_ok(), "{:?}", result.err());
+        let node = result.unwrap();
+        assert_eq!(node.comments.len(), 2);
+        assert_eq!(node.comments[0].comment_type, CommentType::Block);
+        assert_eq!(node.comments[1].comment_type, CommentType::Line);
+    }
+
+    /// Legacy JSON that used the `type` key for comment_kind still parses.
+    #[test]
+    fn test_parse_wrapper_comment_type_alias_type_key() {
+        let adapter = PrismAdapter::new();
+        let json = r##"{
+            "ast": {
+                "node_type": "program_node",
+                "location": {
+                    "start_line": 1,
+                    "start_column": 0,
+                    "end_line": 1,
+                    "end_column": 0,
+                    "start_offset": 0,
+                    "end_offset": 1
+                },
+                "children": [],
+                "metadata": {},
+                "comments": [],
+                "formatting": {
+                    "indent_level": 0,
+                    "needs_blank_line_before": false,
+                    "needs_blank_line_after": false,
+                    "preserve_newlines": false,
+                    "multiline": false,
+                    "original_formatting": null
+                }
+            },
+            "comments": [
+                {
+                    "text": "# hi",
+                    "type": "line",
+                    "location": {
+                        "start_line": 1,
+                        "start_column": 0,
+                        "end_line": 1,
+                        "end_column": 4,
+                        "start_offset": 0,
+                        "end_offset": 4
+                    },
+                    "position": "leading"
+                }
+            ]
+        }"##;
+
+        let node = adapter.parse(json).unwrap();
+        assert_eq!(node.comments.len(), 1);
+        assert_eq!(node.comments[0].comment_type, CommentType::Line);
     }
 }

--- a/ext/rfmt/src/parser/prism_adapter.rs
+++ b/ext/rfmt/src/parser/prism_adapter.rs
@@ -167,7 +167,9 @@ pub enum PrismCommentType {
 
 /// Maps Ruby Prism comment class names (after `PrismBridge` normalization) to our enum.
 /// Unknown values default to `Line` so parsing never fails on new Prism comment kinds.
-fn deserialize_prism_comment_type<'de, D>(deserializer: D) -> std::result::Result<PrismCommentType, D::Error>
+fn deserialize_prism_comment_type<'de, D>(
+    deserializer: D,
+) -> std::result::Result<PrismCommentType, D::Error>
 where
     D: Deserializer<'de>,
 {

--- a/spec/rfmt_spec.rb
+++ b/spec/rfmt_spec.rb
@@ -279,6 +279,22 @@ RSpec.describe Rfmt do
       end
     end
 
+    it 'parses and formats source with embdoc (=begin/=end) comments' do
+      source = <<~RUBY
+        =begin
+        documentation
+        =end
+
+        class Foo
+        end
+      RUBY
+
+      expect { Rfmt.format(source) }.not_to raise_error
+      result = Rfmt.format(source)
+      expect(result).to include('class Foo')
+      expect(Prism.parse(result).success?).to be true
+    end
+
     describe 'inline comments after blocks' do
       it 'preserves inline comments after inline brace blocks' do
         source = "b.each { p it } # c\n"


### PR DESCRIPTION
## Description

Ruby `PrismBridge` が返すトップレベルコメント JSON を、Rust の `PrismComment` で正しく解釈するよう修正しました。`comment_type` キーと `embdoc` / `inline` などの値を扱い、旧形式の `type` キーも読み取ります。

## Motivation

`PrismComment` が `#[serde(rename = "type")]` のため、実際のペイロード `comment_type` と不一致で種別が常にデフォルト化されていました。また `embdoc` や `inline` は列挙子に存在せず、該当コメントを含むソースで JSON 全体のデシリアライズが失敗し得ました。

Fixes #
Related to #

## Changes

- `ext/rfmt/src/parser/prism_adapter.rs`: `comment_type` を主キーに、`type` をエイリアス化。柔軟な `deserialize_prism_comment_type` とユニットテストを追加。
- `spec/rfmt_spec.rb`: `=begin` / `=end` 付きソースの回帰テストを追加。
- `.claude/plans/*.md`: プロジェクト内の計画メモを追加。
- `.direnv/flake-profile` 系: 追跡されていたシンボリックリンクを削除。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes, improves code quality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Test addition/update

## Testing

- [x] All existing tests pass (`bundle exec rspec`)
- [x] Rust tests pass (`cd ext/rfmt && cargo test`)
- [x] Added new tests for new functionality
- [x] Manually tested with the following scenarios:
  - `nix develop` + `bash --noprofile --norc` 上で `bundle exec rake compile` / `bundle exec rspec`
  - embdoc 付きソースの `Rfmt.format` → `Prism.parse` が成功することを確認

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have updated documentation if needed
- [x] My changes generate no new warnings (`cargo clippy`)
- [x] I have added tests that prove my fix/feature works

## Screenshots / Examples

<details>
<summary>Before</summary>

```text
Prism JSON の comment_type: "embdoc" 等でデシリアライズ失敗、または種別が常に Line 扱いになる可能性
```

</details>

<details>
<summary>After</summary>

```text
comment_type / type の両方を受理し、embdoc → Block、inline → Line としてパースが完了
```

</details>

## Additional Notes

- ローカルで `bundle` がシステム Ruby に取られる場合は、`nix develop` 後に `bash --noprofile --norc -c 'bundle exec …'` で実行すると安定します。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes AST/comment deserialization, which can impact how comments are classified and therefore emitted during formatting; mitigated by defaulting unknown values and adding targeted tests.
> 
> **Overview**
> Ensures top-level Prism comments from Ruby `PrismBridge` deserialize correctly by switching `PrismComment` to read `comment_type` (with `type` as an alias) and adding a custom deserializer that maps values like `embdoc` and `inline` to internal comment kinds without failing on unknown values.
> 
> Adds Rust unit coverage for both the new and legacy comment payloads, and adds an RSpec regression test that formatting Ruby with `=begin`/`=end` comments completes successfully and remains parseable. Also adds multiple `.claude/plans/*.md` planning notes and removes committed `.direnv/flake-profile*` link artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1c72927900dd6f6190755a382f2479e0c3d7453. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->