### PR TITLE
Fix: preserve source indent in method chain reformatting

### DIFF
--- a/ext/rfmt/src/format/rule.rs
+++ b/ext/rfmt/src/format/rule.rs
@@ -314,24 +314,47 @@ pub fn format_statements(
     Ok(concat(docs))
 }
 
+/// Returns the number of leading space/tab characters on the line containing `offset`.
+///
+/// The source text extracted by `FormatContext::extract_source` starts at the node's
+/// offset and does not include the whitespace that precedes the first line in the
+/// original source. `Doc::Text` is printed verbatim without re-indenting embedded
+/// newlines, so any reformatting that emits a multi-line string must include the
+/// original leading indent itself.
+pub fn line_leading_indent(source: &str, offset: usize) -> usize {
+    let offset = offset.min(source.len());
+    let line_start = source[..offset].rfind('\n').map(|p| p + 1).unwrap_or(0);
+    source.as_bytes()[line_start..offset]
+        .iter()
+        .take_while(|&&b| b == b' ' || b == b'\t')
+        .count()
+}
+
 /// Reformats multiline method chain text with indented style.
 ///
 /// Converts aligned method chains to indented style:
 /// - First line is kept as-is (trimmed at end)
-/// - Subsequent lines starting with `.` or `&.` are re-indented with one level of indentation
+/// - Subsequent lines starting with `.` or `&.` are re-indented to
+///   `base_indent + indent_width` spaces
+///
+/// `base_indent` is the column at which the first line starts in the original source
+/// (obtain via `line_leading_indent`). Because `Doc::Text` is printed verbatim without
+/// re-indenting embedded newlines, this indent must be included in the returned string.
 ///
 /// Returns `Cow::Borrowed` when no transformation is needed to avoid allocation.
 ///
-/// # Arguments
-/// * `source_text` - The source text containing a method chain
-/// * `indent_width` - The number of spaces for one level of indentation
-///
 /// # Example
 /// ```text
-/// Input (indent_width=2):  "foo.bar\n                  .baz"
-/// Output:                  "foo.bar\n  .baz"
+/// Input (base_indent=4, indent_width=2):
+///   "foo.bar\n                  .baz"
+/// Output:
+///   "foo.bar\n      .baz"
 /// ```
-pub fn reformat_chain_lines(source_text: &str, indent_width: usize) -> std::borrow::Cow<'_, str> {
+pub fn reformat_chain_lines(
+    source_text: &str,
+    base_indent: usize,
+    indent_width: usize,
+) -> std::borrow::Cow<'_, str> {
     use std::borrow::Cow;
 
     let lines: Vec<&str> = source_text.lines().collect();
@@ -350,7 +373,7 @@ pub fn reformat_chain_lines(source_text: &str, indent_width: usize) -> std::borr
     }
 
     // Build the indented chain with pre-allocated capacity
-    let chain_indent = " ".repeat(indent_width);
+    let chain_indent = " ".repeat(base_indent + indent_width);
     let mut result = String::with_capacity(source_text.len());
     result.push_str(lines[0].trim_end());
 
@@ -528,28 +551,51 @@ mod tests {
     #[test]
     fn test_reformat_chain_lines_single_line() {
         let input = "foo.bar.baz";
-        let result = reformat_chain_lines(input, 2);
+        let result = reformat_chain_lines(input, 0, 2);
         assert_eq!(result, "foo.bar.baz");
     }
 
     #[test]
     fn test_reformat_chain_lines_multiline_chain() {
         let input = "foo.bar\n                  .baz\n                  .qux";
-        let result = reformat_chain_lines(input, 2);
+        let result = reformat_chain_lines(input, 0, 2);
         assert_eq!(result, "foo.bar\n  .baz\n  .qux");
     }
 
     #[test]
     fn test_reformat_chain_lines_safe_navigation() {
         let input = "foo&.bar\n                  &.baz";
-        let result = reformat_chain_lines(input, 2);
+        let result = reformat_chain_lines(input, 0, 2);
         assert_eq!(result, "foo&.bar\n  &.baz");
     }
 
     #[test]
     fn test_reformat_chain_lines_no_chain() {
         let input = "foo(\n  arg1,\n  arg2\n)";
-        let result = reformat_chain_lines(input, 2);
+        let result = reformat_chain_lines(input, 0, 2);
         assert_eq!(result, input);
+    }
+
+    #[test]
+    fn test_reformat_chain_lines_preserves_base_indent() {
+        // Simulates a chain inside a 4-space-indented method body:
+        // the caller must include base_indent so the printed continuation
+        // lines up with `base_indent + indent_width` columns.
+        let input = "foo.bar\n                  .baz\n                  .qux";
+        let result = reformat_chain_lines(input, 4, 2);
+        assert_eq!(result, "foo.bar\n      .baz\n      .qux");
+    }
+
+    #[test]
+    fn test_line_leading_indent_counts_spaces_and_tabs() {
+        let source = "def foo\n    bar\n\tbaz\nqux\n";
+        let bar = source.find("bar").unwrap();
+        let baz = source.find("baz").unwrap();
+        let qux = source.find("qux").unwrap();
+        assert_eq!(line_leading_indent(source, bar), 4);
+        assert_eq!(line_leading_indent(source, baz), 1);
+        assert_eq!(line_leading_indent(source, qux), 0);
+        // Out-of-range offset is clamped.
+        assert_eq!(line_leading_indent(source, usize::MAX), 0);
     }
 }

--- a/ext/rfmt/src/format/rules/call.rs
+++ b/ext/rfmt/src/format/rules/call.rs
@@ -12,7 +12,7 @@ use crate::format::context::FormatContext;
 use crate::format::registry::RuleRegistry;
 use crate::format::rule::{
     format_child, format_leading_comments, format_statements, format_trailing_comment,
-    mark_comments_in_range_emitted, reformat_chain_lines, FormatRule,
+    line_leading_indent, mark_comments_in_range_emitted, reformat_chain_lines, FormatRule,
 };
 
 /// Rule for formatting method calls.
@@ -102,8 +102,12 @@ fn format_call(node: &Node, ctx: &mut FormatContext, registry: &RuleRegistry) ->
     if !has_block {
         // Simple call - use source extraction with chain reformatting
         if let Some(source_text) = ctx.extract_source(node) {
-            let reformatted =
-                reformat_chain_lines(source_text, ctx.config().formatting.indent_width);
+            let base_indent = line_leading_indent(ctx.source(), node.location.start_offset);
+            let reformatted = reformat_chain_lines(
+                source_text,
+                base_indent,
+                ctx.config().formatting.indent_width,
+            );
             docs.push(text(reformatted));
         }
 
@@ -129,8 +133,12 @@ fn format_call(node: &Node, ctx: &mut FormatContext, registry: &RuleRegistry) ->
         .source()
         .get(node.location.start_offset..call_end_offset)
     {
-        let reformatted =
-            reformat_chain_lines(call_text.trim_end(), ctx.config().formatting.indent_width);
+        let base_indent = line_leading_indent(ctx.source(), node.location.start_offset);
+        let reformatted = reformat_chain_lines(
+            call_text.trim_end(),
+            base_indent,
+            ctx.config().formatting.indent_width,
+        );
         docs.push(text(reformatted));
     }
 

--- a/ext/rfmt/src/format/rules/fallback.rs
+++ b/ext/rfmt/src/format/rules/fallback.rs
@@ -10,8 +10,8 @@ use crate::error::Result;
 use crate::format::context::FormatContext;
 use crate::format::registry::RuleRegistry;
 use crate::format::rule::{
-    format_leading_comments, format_trailing_comment, mark_comments_in_range_emitted,
-    reformat_chain_lines, FormatRule,
+    format_leading_comments, format_trailing_comment, line_leading_indent,
+    mark_comments_in_range_emitted, reformat_chain_lines, FormatRule,
 };
 
 /// Fallback rule that extracts source text directly.
@@ -38,8 +38,12 @@ impl FormatRule for FallbackRule {
 
         // Extract source text with chain reformatting
         if let Some(source_text) = ctx.extract_source(node) {
-            let reformatted =
-                reformat_chain_lines(source_text, ctx.config().formatting.indent_width);
+            let base_indent = line_leading_indent(ctx.source(), node.location.start_offset);
+            let reformatted = reformat_chain_lines(
+                source_text,
+                base_indent,
+                ctx.config().formatting.indent_width,
+            );
             docs.push(text(reformatted));
 
             // Mark any comments within this node's range as emitted

--- a/ext/rfmt/src/format/rules/variable_write.rs
+++ b/ext/rfmt/src/format/rules/variable_write.rs
@@ -12,8 +12,8 @@ use crate::error::Result;
 use crate::format::context::FormatContext;
 use crate::format::registry::RuleRegistry;
 use crate::format::rule::{
-    format_child, format_leading_comments, format_trailing_comment, reformat_chain_lines,
-    FormatRule,
+    format_child, format_leading_comments, format_trailing_comment, line_leading_indent,
+    reformat_chain_lines, FormatRule,
 };
 
 /// Rule for formatting local variable write expressions.
@@ -111,8 +111,12 @@ fn format_variable_write(
         if is_multiline_call {
             // Multiline call: reformat chain with indented style
             if let Some(source_text) = ctx.extract_source(value) {
-                let reformatted =
-                    reformat_chain_lines(source_text, ctx.config().formatting.indent_width);
+                let base_indent = line_leading_indent(ctx.source(), node.location.start_offset);
+                let reformatted = reformat_chain_lines(
+                    source_text,
+                    base_indent,
+                    ctx.config().formatting.indent_width,
+                );
                 docs.push(text(reformatted.trim_start().to_string()));
             }
         } else {


### PR DESCRIPTION
## Summary

Chain reformatting introduced in v1.6.0 (`reformat_chain_lines`) was dropping
the base indent of the starting line. A chain continuation inside an indented
method body was printed at only `indent_width` columns (e.g. 2 spaces) instead
of `base_indent + indent_width`. Because `Doc::Text` is printed verbatim and
the printer does not re-indent embedded newlines, the reformatted string must
include the full indent itself.

### Before

```ruby
class NotificationsController
  def index
    @notifications = @current_user.notifications.recent
  .includes(:actor, :article, :comment)     # broken: only 2 spaces
  .page(params[:page]).per(params[:per_page] || 20)
  end
end
```

### After

```ruby
class NotificationsController
  def index
    @notifications = @current_user.notifications.recent
      .includes(:actor, :article, :comment) # correct: 4 + 2 = 6 spaces
      .page(params[:page]).per(params[:per_page] || 20)
  end
end
```

## Changes

- Add `line_leading_indent(source, offset)` helper in `format::rule`
- Extend `reformat_chain_lines` signature with `base_indent`:
  `reformat_chain_lines(source, base_indent, indent_width)`
- Thread `base_indent` through all four call sites:
  - `CallRule` (no-block and with-block paths)
  - `FallbackRule`
  - `VariableWriteRule` (multiline chain assignment)
- Update existing unit tests and add coverage for the indented case and for
  `line_leading_indent` (spaces + tabs, out-of-range offset)

## Test plan

- [x] `cargo test --lib` — 127 passed, 0 failed
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --lib --no-deps` — no warnings
- [x] `bundle exec rspec` — 100 examples, 0 failures
- [x] Manual e2e on the reported snippet via `Rfmt.format` — matches expected output

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes formatter output for multiline method chains by incorporating the call site's original leading indent, which may affect many formatted files but is limited to chain reindent logic and its call sites.
> 
> **Overview**
> Fixes multiline method-chain reformatting so continuation lines are indented relative to the *original* column where the chain starts (instead of always starting at `indent_width`).
> 
> Adds a `line_leading_indent` helper and extends `reformat_chain_lines` to accept `base_indent`, then threads this through call formatting (`CallRule`, including block calls), the `FallbackRule`, and multiline chain assignments in `VariableWriteRule`. Updates and expands unit tests to cover base-indent preservation, tabs/spaces handling, and out-of-range offsets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6a83fdb402c7975b0ec382a4ca92a904a7a6e44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->