### PR TITLE
Fix: align rescue/ensure with opener, not body

### DIFF
--- a/ext/rfmt/src/format/rules/begin.rs
+++ b/ext/rfmt/src/format/rules/begin.rs
@@ -13,6 +13,77 @@ use crate::format::rule::{
     format_child, format_leading_comments, format_statements, format_trailing_comment, FormatRule,
 };
 
+/// True when this BeginNode represents an implicit begin (the source does not
+/// start with the `begin` keyword) AND carries at least one rescue/else/ensure
+/// clause. Such bodies need the rescue/else/ensure keywords emitted at the
+/// outer (e.g. `def`) indent level rather than at the body indent level.
+pub(crate) fn is_implicit_begin_with_clauses(node: &Node, ctx: &FormatContext) -> bool {
+    if node.node_type != NodeType::BeginNode {
+        return false;
+    }
+    let has_clause = node.children.iter().any(|c| {
+        matches!(
+            c.node_type,
+            NodeType::RescueNode | NodeType::EnsureNode | NodeType::ElseNode
+        )
+    });
+    if !has_clause {
+        return false;
+    }
+    ctx.extract_source(node)
+        .map(|s| !s.trim_start().starts_with("begin"))
+        .unwrap_or(false)
+}
+
+/// Emits the body of a construct (def/class/module/block) whose body is an
+/// implicit BeginNode with rescue/else/ensure clauses.
+///
+/// The returned Doc is meant to sit between the opening line (e.g. `def foo`)
+/// and a trailing `hardline + text("end")` emitted by the caller. Body
+/// statements are wrapped in `indent`, while rescue/else/ensure clause
+/// keywords are emitted at the caller's current indent level so that they
+/// align with the opener instead of the body.
+pub(crate) fn format_implicit_begin_body(
+    node: &Node,
+    ctx: &mut FormatContext,
+    registry: &RuleRegistry,
+) -> Result<Doc> {
+    let mut body_children: Vec<&Node> = Vec::new();
+    let mut clause_children: Vec<&Node> = Vec::new();
+
+    for child in &node.children {
+        match child.node_type {
+            NodeType::RescueNode | NodeType::EnsureNode | NodeType::ElseNode => {
+                clause_children.push(child);
+            }
+            _ => {
+                body_children.push(child);
+            }
+        }
+    }
+
+    let mut docs: Vec<Doc> = Vec::with_capacity(clause_children.len() * 2 + 2);
+
+    if !body_children.is_empty() {
+        let mut body_docs: Vec<Doc> = Vec::with_capacity(body_children.len() * 2 + 1);
+        body_docs.push(hardline());
+        for (i, child) in body_children.iter().enumerate() {
+            if i > 0 {
+                body_docs.push(hardline());
+            }
+            body_docs.push(format_child(child, ctx, registry)?);
+        }
+        docs.push(indent(concat(body_docs)));
+    }
+
+    for clause in clause_children {
+        docs.push(hardline());
+        docs.push(format_child(clause, ctx, registry)?);
+    }
+
+    Ok(concat(docs))
+}
+
 /// Rule for formatting begin/rescue/ensure blocks.
 pub struct BeginRule;
 
@@ -71,14 +142,36 @@ fn format_explicit_begin(
     }
 
     docs.push(text("begin"));
-    docs.push(hardline());
 
+    let mut body_children: Vec<&Node> = Vec::new();
+    let mut clause_children: Vec<&Node> = Vec::new();
     for child in &node.children {
-        let child_doc = format_child(child, ctx, registry)?;
-        docs.push(child_doc);
-        docs.push(hardline());
+        match child.node_type {
+            NodeType::RescueNode | NodeType::EnsureNode | NodeType::ElseNode => {
+                clause_children.push(child);
+            }
+            _ => body_children.push(child),
+        }
     }
 
+    if !body_children.is_empty() {
+        let mut body_docs: Vec<Doc> = Vec::with_capacity(body_children.len() * 2 + 1);
+        body_docs.push(hardline());
+        for (i, child) in body_children.iter().enumerate() {
+            if i > 0 {
+                body_docs.push(hardline());
+            }
+            body_docs.push(format_child(child, ctx, registry)?);
+        }
+        docs.push(indent(concat(body_docs)));
+    }
+
+    for clause in &clause_children {
+        docs.push(hardline());
+        docs.push(format_child(clause, ctx, registry)?);
+    }
+
+    docs.push(hardline());
     docs.push(text("end"));
 
     // Trailing comment on end line
@@ -167,24 +260,30 @@ fn format_rescue(
         }
     }
 
-    docs.push(hardline());
-
-    // Emit rescue body and handle subsequent rescue nodes
+    // Emit rescue body (indented under the rescue keyword) and subsequent
+    // chained rescue clauses (at the same indent level as this rescue).
+    //
+    // The hardline lives INSIDE the `indent(...)` wrap so that the body's
+    // first statement lands at `caller_indent + indent_width`, matching the
+    // indentation applied by hardlines later inside `format_statements`.
+    let mut body_stmts: Option<&Node> = None;
+    let mut subsequent: Option<&Node> = None;
     for child in &node.children {
         match &child.node_type {
-            NodeType::StatementsNode => {
-                let body_doc = format_statements(child, ctx, registry)?;
-                docs.push(indent(body_doc));
-            }
-            NodeType::RescueNode => {
-                // Emit subsequent rescue clause
-                let rescue_doc = format_rescue(child, ctx, registry, dedent_level)?;
-                docs.push(rescue_doc);
-            }
-            _ => {
-                // Skip exception classes and variable (already handled above)
-            }
+            NodeType::StatementsNode => body_stmts = Some(child),
+            NodeType::RescueNode => subsequent = Some(child),
+            _ => {}
         }
+    }
+
+    if let Some(stmts) = body_stmts {
+        let body_doc = format_statements(stmts, ctx, registry)?;
+        docs.push(indent(concat(vec![hardline(), body_doc])));
+    }
+
+    if let Some(sub) = subsequent {
+        docs.push(hardline());
+        docs.push(format_rescue(sub, ctx, registry, dedent_level)?);
     }
 
     Ok(concat(docs))
@@ -207,18 +306,19 @@ fn format_ensure(
     }
 
     docs.push(text("ensure"));
-    docs.push(hardline());
 
-    // Emit ensure body statements
+    // Emit ensure body. The hardline lives INSIDE the `indent(...)` wrap so
+    // that every body statement — including the first one — lands at
+    // `caller_indent + indent_width`.
     for child in &node.children {
         match &child.node_type {
             NodeType::StatementsNode => {
                 let body_doc = format_statements(child, ctx, registry)?;
-                docs.push(indent(body_doc));
+                docs.push(indent(concat(vec![hardline(), body_doc])));
             }
             _ => {
                 let child_doc = format_child(child, ctx, registry)?;
-                docs.push(indent(child_doc));
+                docs.push(indent(concat(vec![hardline(), child_doc])));
             }
         }
     }

--- a/ext/rfmt/src/format/rules/body_end.rs
+++ b/ext/rfmt/src/format/rules/body_end.rs
@@ -13,6 +13,8 @@ use crate::format::rule::{
     is_structural_node,
 };
 
+use super::begin::{format_implicit_begin_body, is_implicit_begin_with_clauses};
+
 /// Configuration for formatting a body-with-end construct.
 pub struct BodyEndConfig<'a> {
     /// The keyword (e.g., "class", "module", "def")
@@ -63,27 +65,31 @@ pub fn format_body_end(
     }
 
     // 4. Body (children), skipping structural nodes
-    let mut body_docs: Vec<Doc> = Vec::new();
-    let mut has_body_content = false;
+    let body_children: Vec<&Node> = config
+        .node
+        .children
+        .iter()
+        .filter(|c| {
+            if config.skip_same_line_children && c.location.start_line == start_line {
+                return false;
+            }
+            !is_structural_node(c)
+        })
+        .collect();
 
-    for child in &config.node.children {
-        // Skip nodes on the same line as definition (name, parameters, etc.)
-        if config.skip_same_line_children && child.location.start_line == start_line {
-            continue;
+    // Special case: body is an implicit BeginNode carrying rescue/else/ensure.
+    // In that case the clause keywords must align with the opener, not with
+    // the body statements — so we split the body and clause emission instead
+    // of wrapping everything in a single `indent(...)`.
+    if body_children.len() == 1 && is_implicit_begin_with_clauses(body_children[0], ctx) {
+        docs.push(format_implicit_begin_body(body_children[0], ctx, registry)?);
+    } else if !body_children.is_empty() {
+        let mut body_docs: Vec<Doc> = Vec::with_capacity(body_children.len() * 2);
+        for child in &body_children {
+            let child_doc = format_child(child, ctx, registry)?;
+            body_docs.push(hardline());
+            body_docs.push(child_doc);
         }
-        if is_structural_node(child) {
-            continue;
-        }
-
-        has_body_content = true;
-
-        // Format the child node using recursive rule dispatch
-        let child_doc = format_child(child, ctx, registry)?;
-        body_docs.push(hardline());
-        body_docs.push(child_doc);
-    }
-
-    if has_body_content {
         docs.push(indent(concat(body_docs)));
     }
 

--- a/ext/rfmt/src/format/rules/call.rs
+++ b/ext/rfmt/src/format/rules/call.rs
@@ -209,9 +209,16 @@ fn format_do_end_block(
                 break;
             }
             NodeType::BeginNode => {
-                // Block with rescue/ensure/else
-                let body_doc = format_child(child, ctx, registry)?;
-                docs.push(indent(concat(vec![hardline(), body_doc])));
+                // Block with rescue/else/ensure needs the clause keywords at
+                // the block opener's indent level, not at the body indent.
+                if super::begin::is_implicit_begin_with_clauses(child, ctx) {
+                    docs.push(super::begin::format_implicit_begin_body(
+                        child, ctx, registry,
+                    )?);
+                } else {
+                    let body_doc = format_child(child, ctx, registry)?;
+                    docs.push(indent(concat(vec![hardline(), body_doc])));
+                }
                 break;
             }
             _ => {

--- a/spec/rescue_indent_spec.rb
+++ b/spec/rescue_indent_spec.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Rfmt, 'Rescue/Ensure Indentation' do
+  def normalize(source)
+    source.gsub(/[ \t]+\n/, "\n").chomp
+  end
+
+  describe 'def with rescue' do
+    it 'keeps rescue aligned with def and body indented one level deeper' do
+      source = <<~RUBY
+        def baz
+          risky!
+        rescue
+          handle!
+          cleanup!
+        end
+      RUBY
+      expected = <<~RUBY.chomp
+        def baz
+          risky!
+        rescue
+          handle!
+          cleanup!
+        end
+      RUBY
+      expect(normalize(Rfmt.format(source))).to eq(expected)
+    end
+
+    it 'keeps rescue aligned with def when nested inside a class' do
+      source = <<~RUBY
+        module Admins
+          class SessionsController
+            def create
+              authenticate!
+              respond_with(resource)
+            rescue StandardError
+              flash[:alert] = 'nope'
+              redirect_to login_path
+            end
+          end
+        end
+      RUBY
+      expected = <<~RUBY.chomp
+        module Admins
+          class SessionsController
+            def create
+              authenticate!
+              respond_with(resource)
+            rescue StandardError
+              flash[:alert] = 'nope'
+              redirect_to login_path
+            end
+          end
+        end
+      RUBY
+      expect(normalize(Rfmt.format(source))).to eq(expected)
+    end
+
+    it 'handles chained rescue clauses' do
+      source = <<~RUBY
+        def foo
+          body!
+        rescue ArgumentError => e
+          handle_arg(e)
+        rescue StandardError => e
+          handle_std(e)
+        end
+      RUBY
+      expected = <<~RUBY.chomp
+        def foo
+          body!
+        rescue ArgumentError => e
+          handle_arg(e)
+        rescue StandardError => e
+          handle_std(e)
+        end
+      RUBY
+      expect(normalize(Rfmt.format(source))).to eq(expected)
+    end
+
+    it 'handles rescue followed by ensure' do
+      source = <<~RUBY
+        def foo
+          work!
+        rescue StandardError => e
+          log(e)
+        ensure
+          cleanup!
+        end
+      RUBY
+      expected = <<~RUBY.chomp
+        def foo
+          work!
+        rescue StandardError => e
+          log(e)
+        ensure
+          cleanup!
+        end
+      RUBY
+      expect(normalize(Rfmt.format(source))).to eq(expected)
+    end
+
+    it 'handles ensure-only clause' do
+      source = <<~RUBY
+        def foo
+          work!
+        ensure
+          cleanup!
+          log!
+        end
+      RUBY
+      expected = <<~RUBY.chomp
+        def foo
+          work!
+        ensure
+          cleanup!
+          log!
+        end
+      RUBY
+      expect(normalize(Rfmt.format(source))).to eq(expected)
+    end
+  end
+
+  describe 'do...end block with rescue' do
+    it 'aligns rescue with the block opener and indents the body' do
+      source = <<~RUBY
+        foo.each do |x|
+          transform(x)
+        rescue StandardError => e
+          log(e)
+          raise
+        end
+      RUBY
+      expected = <<~RUBY.chomp
+        foo.each do |x|
+          transform(x)
+        rescue StandardError => e
+          log(e)
+          raise
+        end
+      RUBY
+      expect(normalize(Rfmt.format(source))).to eq(expected)
+    end
+  end
+
+  describe 'explicit begin...end' do
+    it 'indents begin body and aligns rescue/ensure with begin' do
+      source = <<~RUBY
+        def outer
+          begin
+            risky!
+            more!
+          rescue StandardError
+            handle!
+          ensure
+            cleanup!
+          end
+        end
+      RUBY
+      expected = <<~RUBY.chomp
+        def outer
+          begin
+            risky!
+            more!
+          rescue StandardError
+            handle!
+          ensure
+            cleanup!
+          end
+        end
+      RUBY
+      expect(normalize(Rfmt.format(source))).to eq(expected)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `def ... rescue ... end` and `do ... rescue ... end` now emit the `rescue`/`ensure`/`else` keyword at the opener's indent level, with body statements one level deeper. Before this fix, `rescue` inherited the body indent and the second rescue-body statement gained an extra level of indent.
- Explicit `begin ... end` blocks now indent their body under `begin` (they were being emitted at the same column as `begin`/`end`).
- Chained `rescue A ... rescue B ...` clauses now have a proper line break between them.

## Before / after

```ruby
# input
def create
  authenticate!
  respond_with(resource)
rescue StandardError
  flash[:alert] = 'nope'
  redirect_to login_path
end
```

```ruby
# before (buggy)
def create
  authenticate!
  respond_with(resource)
  rescue StandardError             # wrong indent
  flash[:alert] = 'nope'
    redirect_to login_path         # wrong indent
end

# after (this PR)
def create
  authenticate!
  respond_with(resource)
rescue StandardError
  flash[:alert] = 'nope'
  redirect_to login_path
end
```

## Root cause
Two interacting bugs in the Doc IR pipeline:

1. `format_body_end` wraps the whole body in a single `indent(...)`. The body of a `def` with rescue is an implicit `BeginNode` whose children include the rescue clause, so the rescue keyword inherited the body indent. The Doc IR has no dedent operator, so the fix splits emission: body statements wrapped in `indent`, clause keywords (`rescue`/`else`/`ensure`) emitted at the caller's indent level.
2. `format_rescue` / `format_ensure` placed the trailing `hardline()` *outside* the `indent(body)` wrapper. That landed the first body statement at the caller's column while subsequent `hardline()`s inside `format_statements` used the incremented indent — producing a mismatched first line. Moving the `hardline()` inside the `indent(...)` fixes every body line uniformly.

`format_explicit_begin` had a symmetric but distinct bug (the body was never wrapped in `indent` at all). Same body/clause split applied.

## Changes
- `ext/rfmt/src/format/rules/begin.rs`
  - Add `is_implicit_begin_with_clauses` + `format_implicit_begin_body` helpers.
  - Rewrite `format_explicit_begin` to split body/clauses and indent body.
  - Rewrite `format_rescue` / `format_ensure` with the hardline moved inside the `indent(...)` wrap.
  - Emit a `hardline` between chained rescue clauses.
- `ext/rfmt/src/format/rules/body_end.rs` — when the sole non-structural body child is an implicit begin with clauses, route it through the new helper instead of the generic `indent(body_docs)`.
- `ext/rfmt/src/format/rules/call.rs` (`format_do_end_block`) — same routing for `do … rescue … end` block bodies.
- `spec/rescue_indent_spec.rb` — new spec asserting the exact formatted output for: `def` + rescue, nested def inside class/module, chained rescue, rescue + ensure, ensure-only, do/end block rescue, explicit `begin`.

## Out of scope
An unrelated pre-existing bug where `ElseNode` inside `begin ... rescue ... else ... ensure ... end` duplicates the `ensure` keyword (the else clause's source range extends into the ensure keyword via `FallbackRule`). This PR does not introduce or worsen that behavior and does not attempt to fix it.

## Test plan
- [x] `cargo test --manifest-path ext/rfmt/Cargo.toml --lib` — 127 passed
- [x] `bundle exec rspec` — 107 passed (100 existing + 7 new)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `bundle exec rubocop spec/rescue_indent_spec.rb` — no offenses
- [x] Manual formatting of the original reported snippet now produces the expected indentation and is idempotent under a second pass.