### PR TITLE
Fix: second sweep of Rails-idiom formatting bugs

### DIFF
--- a/ext/rfmt/src/format/rule.rs
+++ b/ext/rfmt/src/format/rule.rs
@@ -454,6 +454,21 @@ pub fn reformat_chain_lines(
         return Cow::Borrowed(source_text);
     }
 
+    // Skip reformatting when the first line opens a new scope (a `{` brace
+    // lambda, a `do` block, or a `do |params|` block). The `.method` lines
+    // that follow are chain continuations *inside the block body*, not of
+    // the outer call — re-indenting them relative to the outer
+    // `base_indent` collapses the nested chain one level to the left and
+    // breaks the visual structure of the block body.
+    //
+    // This deliberately keeps the reformat conservative: for a top-level
+    // `User.active.where(...)` chain, line 1 ends with an identifier so
+    // we still rewrite aligned → indented as PR #100 intended.
+    let first_line = lines[0].trim_end();
+    if first_line.ends_with('{') || first_line.ends_with(" do") || first_line.ends_with('|') {
+        return Cow::Borrowed(source_text);
+    }
+
     // Check if there are actual chain continuation lines (. or &.)
     let has_chain = lines[1..].iter().any(|l| {
         let t = l.trim_start();

--- a/ext/rfmt/src/format/rules/begin.rs
+++ b/ext/rfmt/src/format/rules/begin.rs
@@ -78,9 +78,39 @@ pub(crate) fn format_implicit_begin_body(
 
     for clause in clause_children {
         docs.push(hardline());
-        docs.push(format_child(clause, ctx, registry)?);
+        docs.push(format_begin_clause(clause, ctx, registry)?);
     }
 
+    Ok(concat(docs))
+}
+
+/// Emits a rescue/else/ensure clause the way the enclosing begin expects.
+///
+/// `format_child` sends ElseNode to `FallbackRule`, which slices the source
+/// between `else` and the next keyword — but Prism's `ElseNode.location`
+/// stretches into the *following* clause's keyword (`ensure`, or the
+/// begin's `end`). Emitting that slice as-is duplicates whichever keyword
+/// comes after, producing e.g. `else\n  y\nensure\nensure\n  z\nend` or
+/// `else\n  y\nend\nend`. Handle ElseNode explicitly so we emit only
+/// `else\n  body` and let the caller (or the subsequent EnsureRule) write
+/// the following keyword.
+fn format_begin_clause(
+    clause: &Node,
+    ctx: &mut FormatContext,
+    registry: &RuleRegistry,
+) -> Result<Doc> {
+    if !matches!(clause.node_type, NodeType::ElseNode) {
+        return format_child(clause, ctx, registry);
+    }
+
+    let mut docs: Vec<Doc> = Vec::with_capacity(3);
+    docs.push(text("else"));
+    for child in &clause.children {
+        if matches!(child.node_type, NodeType::StatementsNode) {
+            let body_doc = format_statements(child, ctx, registry)?;
+            docs.push(indent(concat(vec![hardline(), body_doc])));
+        }
+    }
     Ok(concat(docs))
 }
 
@@ -168,7 +198,7 @@ fn format_explicit_begin(
 
     for clause in &clause_children {
         docs.push(hardline());
-        docs.push(format_child(clause, ctx, registry)?);
+        docs.push(format_begin_clause(clause, ctx, registry)?);
     }
 
     docs.push(hardline());

--- a/ext/rfmt/src/format/rules/body_end.rs
+++ b/ext/rfmt/src/format/rules/body_end.rs
@@ -71,18 +71,8 @@ pub fn format_body_end(
         }
     }
 
-    // 2. Build header: "keyword ..."
-    let mut header_parts: Vec<Doc> = vec![text(config.keyword), text(" ")];
-    header_parts.extend((config.header_builder)(config.node));
-    docs.push(concat(header_parts));
-
-    // 3. Trailing comment on definition line
-    let trailing = format_trailing_comment(ctx, start_line);
-    if !trailing.is_empty() {
-        docs.push(trailing);
-    }
-
-    // 4. Body (children), skipping structural nodes
+    // Body children (filtered) — reused by both the multi-line header path
+    // below and the normal path further down.
     let body_children: Vec<&Node> = config
         .node
         .children
@@ -94,6 +84,60 @@ pub fn format_body_end(
             !is_structural_node(c)
         })
         .collect();
+
+    // Multi-line header form: `def foo(a, # c1\n  b, # c2\n  c) # c3`.
+    //
+    // Rebuilding the header from `parameters_text` + a reconstructed `)`
+    // drops the closing line's trailing comment and, worse, lets comments
+    // that the params slice already contains be re-picked up by the later
+    // `format_trailing_comment` + `format_leading_comments` calls. The net
+    // effect is that the first inline comment is duplicated, the rest are
+    // moved into the body, and the file stops being idempotent because the
+    // relocated comments keep accumulating every format pass. Detect this
+    // case early and emit the header verbatim from source.
+    let params_text = config.node.metadata.get("parameters_text");
+    let header_is_multiline = params_text.is_some_and(|t| t.contains('\n'));
+    if header_is_multiline {
+        let header_end_line = body_children
+            .first()
+            .map(|c| c.location.start_line.saturating_sub(1))
+            .unwrap_or(start_line);
+        if header_end_line >= start_line {
+            let header_end_offset = line_end_offset(ctx.source(), header_end_line);
+            if let Some(header_src) = ctx
+                .source()
+                .get(config.node.location.start_offset..header_end_offset)
+            {
+                docs.push(text(header_src.to_string()));
+                mark_comments_in_range_emitted(ctx, start_line, header_end_line + 1);
+
+                // Body + "end" (same as the normal path; no header trailing
+                // comment — it's already baked into the source slice above).
+                push_body_and_end(
+                    &mut docs,
+                    ctx,
+                    registry,
+                    &body_children,
+                    start_line,
+                    end_line,
+                )?;
+                return Ok(concat(docs));
+            }
+        }
+    }
+
+    // 2. Build header: "keyword ..."
+    let mut header_parts: Vec<Doc> = vec![text(config.keyword), text(" ")];
+    header_parts.extend((config.header_builder)(config.node));
+    docs.push(concat(header_parts));
+
+    // 3. Trailing comment on definition line
+    let trailing = format_trailing_comment(ctx, start_line);
+    if !trailing.is_empty() {
+        docs.push(trailing);
+    }
+
+    // 4. Body (children), skipping structural nodes — already collected above.
 
     // Special case: body is an implicit BeginNode carrying rescue/else/ensure.
     // In that case the clause keywords must align with the opener, not with
@@ -130,4 +174,60 @@ pub fn format_body_end(
     }
 
     Ok(concat(docs))
+}
+
+/// Returns the byte offset of the character immediately past the end of the
+/// given 1-based line (i.e. the index of the trailing `\n`, or `source.len()`
+/// if the line has no trailing newline).
+fn line_end_offset(source: &str, line: usize) -> usize {
+    let mut current = 1;
+    for (i, b) in source.bytes().enumerate() {
+        if b == b'\n' {
+            if current == line {
+                return i;
+            }
+            current += 1;
+        }
+    }
+    source.len()
+}
+
+/// Emits the body (possibly an implicit BeginNode with rescue clauses) and the
+/// trailing `end` keyword. Extracted so that both the standard
+/// header-reconstruction path and the multi-line source-extraction path can
+/// share the emission logic.
+fn push_body_and_end(
+    docs: &mut Vec<Doc>,
+    ctx: &mut FormatContext,
+    registry: &RuleRegistry,
+    body_children: &[&Node],
+    start_line: usize,
+    end_line: usize,
+) -> Result<()> {
+    if body_children.len() == 1 && is_implicit_begin_with_clauses(body_children[0], ctx) {
+        docs.push(format_implicit_begin_body(body_children[0], ctx, registry)?);
+    } else if !body_children.is_empty() {
+        let mut body_docs: Vec<Doc> = Vec::with_capacity(body_children.len() * 2);
+        for child in body_children {
+            let child_doc = format_child(child, ctx, registry)?;
+            body_docs.push(hardline());
+            body_docs.push(child_doc);
+        }
+        docs.push(indent(concat(body_docs)));
+    }
+
+    let comments_before_end = format_comments_before_end(ctx, start_line, end_line);
+    if !comments_before_end.is_empty() {
+        docs.push(indent(comments_before_end));
+    }
+
+    docs.push(hardline());
+    docs.push(text("end"));
+
+    let end_trailing = format_trailing_comment(ctx, end_line);
+    if !end_trailing.is_empty() {
+        docs.push(end_trailing);
+    }
+
+    Ok(())
 }

--- a/ext/rfmt/src/format/rules/if_unless.rs
+++ b/ext/rfmt/src/format/rules/if_unless.rs
@@ -13,7 +13,8 @@ use crate::error::Result;
 use crate::format::context::FormatContext;
 use crate::format::registry::RuleRegistry;
 use crate::format::rule::{
-    format_leading_comments, format_statements, format_trailing_comment, FormatRule,
+    format_leading_comments, format_statements, format_trailing_comment,
+    strip_one_trailing_newline, FormatRule,
 };
 
 /// Rule for formatting if conditionals.
@@ -101,9 +102,30 @@ fn format_postfix(
         docs.push(leading);
     }
 
-    // Emit statement
+    // Emit statement. When the statement contains a heredoc whose body
+    // spills past the opener line, the bridge extends the statement's
+    // end_offset to cover the terminator — and that extended slice *also*
+    // sweeps in the intervening `if cond` modifier text that sits between
+    // the opener's `)` and the heredoc body. Appending our own
+    // ` if <cond>` after that text would then either produce
+    // `... if cond if cond` (duplicated modifier) or, worse, land the
+    // modifier on the same line as `SQL`, breaking heredoc termination.
+    //
+    // Detect the heredoc-in-statement case and emit the slice verbatim;
+    // the modifier is already baked into the source text right where
+    // Ruby expects it.
     if let Some(statements) = node.children.get(1) {
         if let Some(source_text) = ctx.extract_source(statements) {
+            if statement_contains_heredoc_tail(source_text) {
+                docs.push(text(source_text.trim_end_matches('\n').to_string()));
+
+                let trailing = format_trailing_comment(ctx, node.location.end_line);
+                if !trailing.is_empty() {
+                    docs.push(trailing);
+                }
+                return Ok(concat(docs));
+            }
+
             docs.push(text(source_text.trim()));
         }
     }
@@ -126,6 +148,26 @@ fn format_postfix(
     }
 
     Ok(concat(docs))
+}
+
+/// True if `source` looks like `<opener_with_heredoc>…\n<body>\n<TERMINATOR>`:
+/// that is, line 1 contains a heredoc opening marker (`<<~`, `<<-`, `<<`) and
+/// at least one subsequent line is not a chain continuation. The bridge
+/// extends the node's end_offset to cover the heredoc tail, so this slice
+/// already contains any `if`/`unless` modifier that was typed between the
+/// opener's closing paren and the heredoc body on the opener line.
+fn statement_contains_heredoc_tail(source: &str) -> bool {
+    let source = source.trim_end_matches('\n');
+    let Some((first, rest)) = source.split_once('\n') else {
+        return false;
+    };
+    if !first.contains("<<~") && !first.contains("<<-") && !first.contains("<<") {
+        return false;
+    }
+    rest.lines().any(|l| {
+        let t = l.trim_start();
+        !t.is_empty() && !t.starts_with('.') && !t.starts_with("&.")
+    })
 }
 
 /// Formats ternary operator: `cond ? then_expr : else_expr`
@@ -240,10 +282,15 @@ fn format_normal(
         docs.push(text(" "));
     }
 
-    // Emit predicate (condition)
+    // Emit predicate (condition). When the predicate is something like
+    // `(sql = <<~SQL)`, Prism's bridge stretches the heredoc-containing
+    // nodes' end_offset past the terminator's newline. Leaving that
+    // newline in the emitted text combines with our own `hardline` before
+    // the then-clause to produce a spurious blank line after the
+    // terminator. Strip at most one trailing newline.
     if let Some(predicate) = node.children.first() {
         if let Some(source_text) = ctx.extract_source(predicate) {
-            docs.push(text(source_text));
+            docs.push(text(strip_one_trailing_newline(source_text).to_string()));
         }
     }
 

--- a/ext/rfmt/src/format/rules/variable_write.rs
+++ b/ext/rfmt/src/format/rules/variable_write.rs
@@ -88,7 +88,14 @@ fn format_variable_write(
             | NodeType::ForNode
     );
 
-    if is_block_value {
+    // Only split the assignment across two lines when the block value
+    // actually begins below the `=`. When the user wrote
+    // `x = begin\n  …\nend` (the opener is on the same line as the
+    // assignment), preserve that shape — splitting it mangles a common
+    // Rails idiom used for defaulted constants and service objects.
+    let inline_block_value = is_block_value && value.location.start_line == start_line;
+
+    if is_block_value && !inline_block_value {
         // Block value: format on new line with indent
         // x =
         //   if true
@@ -101,6 +108,9 @@ fn format_variable_write(
             hardline(),
             format_child(value, ctx, registry)?,
         ])));
+    } else if inline_block_value {
+        docs.push(text(format!("{} = ", name)));
+        docs.push(format_child(value, ctx, registry)?);
     } else {
         // Check for multiline method chain
         let is_multiline_call = matches!(value.node_type, NodeType::CallNode)

--- a/lib/rfmt/prism_bridge.rb
+++ b/lib/rfmt/prism_bridge.rb
@@ -448,9 +448,16 @@ module Rfmt
           metadata['name'] = name
         end
       when Prism::DefNode
-        if (name = extract_node_name(node))
-          metadata['name'] = name
-        end
+        # Prefer `name_loc.slice` over `name.to_s` so unary operator suffixes
+        # (`def !@`, `def +@`, `def -@`) survive the round-trip. Prism
+        # normalizes `name` to the symbol with the `@` stripped for `!@`,
+        # which would otherwise rewrite `def !@` to `def !` silently.
+        name = if node.respond_to?(:name_loc) && node.name_loc
+                 node.name_loc.slice
+               else
+                 extract_node_name(node)
+               end
+        metadata['name'] = name if name
         metadata['parameters_count'] = extract_parameter_count(node).to_s
         # Extract parameters text directly from source
         if node.parameters

--- a/spec/rails_idioms_round2_spec.rb
+++ b/spec/rails_idioms_round2_spec.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Rfmt, 'Rails idioms — round 2' do
+  def idempotent(source)
+    first = Rfmt.format(source)
+    second = Rfmt.format(first)
+    expect(second).to eq(first), "non-idempotent output:\n#{first}"
+    first
+  end
+
+  def parses_cleanly?(code)
+    require 'prism'
+    Prism.parse(code).errors.none?
+  end
+
+  describe 'else/ensure clause overshoot (bugs #4/#5)' do
+    it 'does not duplicate `end` when begin/rescue/else is followed by end' do
+      source = <<~RUBY
+        def example
+          begin
+            body
+          rescue => e
+            handle(e)
+          else
+            success
+          end
+        end
+      RUBY
+      formatted = idempotent(source)
+      expect(formatted.scan(/^\s*end$/m).size).to eq(2)
+      expect(parses_cleanly?(formatted)).to be true
+    end
+
+    it 'does not duplicate `ensure` when begin has both else and ensure' do
+      source = <<~RUBY
+        def example
+          begin
+            body
+          rescue => e
+            handle(e)
+          else
+            success
+          ensure
+            cleanup
+          end
+        end
+      RUBY
+      formatted = idempotent(source)
+      expect(formatted.scan(/\bensure\b/).size).to eq(1)
+      expect(parses_cleanly?(formatted)).to be true
+    end
+  end
+
+  describe 'heredoc + postfix modifier (bug #3)' do
+    it 'keeps the `if` modifier on the opener line, not the terminator line' do
+      source = <<~RUBY
+        def example(params)
+          scope = []
+          scope.push(<<~SQL, type: params[:type]) if params[:type]
+            SELECT 1
+          SQL
+          scope
+        end
+      RUBY
+      formatted = idempotent(source)
+      # The opener line must carry `if params[:type]`; the SQL terminator
+      # must sit alone (leading whitespace only) so Ruby recognizes it.
+      expect(formatted).to include('<<~SQL, type: params[:type]) if params[:type]')
+      expect(formatted).to match(/^\s*SQL$/m)
+      expect(parses_cleanly?(formatted)).to be true
+    end
+  end
+
+  describe 'multi-line def header with inline comments (bug #2)' do
+    it 'preserves inline comments on each parameter line idempotently' do
+      source = <<~RUBY
+        class C
+          def demo(a, # first
+                   b, # second
+                   c) # third
+            [a, b, c]
+          end
+        end
+      RUBY
+      formatted = idempotent(source)
+      # Each comment should appear exactly once.
+      %w[first second third].each do |suffix|
+        expect(formatted.scan(/# #{suffix}/).size).to eq(1), "expected # #{suffix} once, got:\n#{formatted}"
+      end
+      expect(parses_cleanly?(formatted)).to be true
+    end
+  end
+
+  describe '`x = begin … end` inline (bug #6)' do
+    it 'keeps the begin keyword on the same line as the assignment' do
+      source = <<~RUBY
+        class C
+          def demo
+            x = begin
+              1
+            rescue StandardError
+              2
+            end
+            x
+          end
+        end
+      RUBY
+      formatted = idempotent(source)
+      expect(formatted).to include('    x = begin')
+      expect(parses_cleanly?(formatted)).to be true
+    end
+  end
+
+  describe 'chain reformat respects block scope (bug #9)' do
+    it 'does not collapse chain continuations inside a brace lambda' do
+      source = <<~RUBY
+        class C
+          scope :active_in, ->(period) {
+            where(active: true)
+              .where(last_seen_at: period)
+          }
+        end
+      RUBY
+      formatted = idempotent(source)
+      # The inner `.where(last_seen_at: …)` must remain indented relative
+      # to the receiver `where(active: true)` inside the lambda body.
+      expect(formatted).to include("    where(active: true)\n      .where(last_seen_at: period)")
+    end
+
+    it 'does not collapse chain continuations inside a do…end block' do
+      source = <<~RUBY
+        foo.each do |x|
+          transform(x)
+            .other
+        end
+      RUBY
+      formatted = idempotent(source)
+      expect(formatted).to include("  transform(x)\n    .other")
+    end
+  end
+
+  describe 'heredoc in `if` predicate (bug #10)' do
+    it 'does not insert a blank line after the heredoc terminator' do
+      source = <<~RUBY
+        def demo
+          if (sql = <<~SQL)
+            SELECT 1
+          SQL
+            execute(sql)
+          end
+        end
+      RUBY
+      formatted = idempotent(source)
+      expect(formatted).to match(/SQL\n    execute/)
+    end
+  end
+
+  describe 'unary `!@` method name' do
+    it 'preserves the `@` suffix on `def !@`' do
+      source = <<~RUBY
+        class C
+          def !@
+            false
+          end
+        end
+      RUBY
+      formatted = idempotent(source)
+      expect(formatted).to include('def !@')
+      expect(parses_cleanly?(formatted)).to be true
+    end
+  end
+end


### PR DESCRIPTION
Re-opens #103 now that #102 has landed and its base branch was deleted. This PR now targets `main` directly; no content changes from #103.

## Summary
Seven more formatter bugs surfaced by a systematic walk through Rails-flavoured Ruby patterns that weren't covered by #102. Three of them caused the formatter to emit code that no longer parses; the rest silently reshape user style.

## Bugs fixed

| ID | Severity | Symptom | Root cause |
|---|---|---|---|
| **#4 / #5** | Syntax break | `begin/rescue/else/ensure/end` → `else...\nensure\nensure\n...\nend`; `begin/rescue/else/end` → `else...\nend\nend` | Prism's `ElseNode.location` extends through the *next* clause keyword. The fallback rule's source-slice emission therefore re-prints whatever comes after — duplicating `ensure` or `end`. |
| **#3** | Syntax break | `foo(<<~SQL, …) if cond\n  …\nSQL` → `foo(…) if cond\n  …\nSQL if cond` — the `if` modifier sticks to the terminator line, so Ruby never closes the heredoc. | The bridge extends a heredoc-carrying statement's `end_offset` past the terminator, and the extended slice already contains the modifier text, but `format_postfix` still appended ` if cond` after it. |
| **#2** | Comment corruption + non-idempotence | `def demo(a, # c1\n  b, # c2\n  c) # c3` duplicated the first comment, ejected the rest into the body, and **each format pass duplicated them again**. | `build_def_header` rebuilds the signature from `parameters_text`, and later `format_trailing_comment` / `format_leading_comments` calls re-collect comments already embedded in the slice. |
| **#9** | Indent collapse | Chain continuations inside a brace-lambda / do-block (`scope :x, -> { where(...)\n  .where(...) }`) were re-indented to the *outer* `base_indent`, erasing the nested scope. | `reformat_chain_lines` treats any `.xxx` line as chain continuation regardless of nesting. |
| **#10** | Blank-line insertion | `if (sql = <<~SQL)\n  …\nSQL\n  execute(sql)` gained a blank line between the terminator and `execute`. | The predicate's source slice retained the trailing `\n` past the heredoc terminator, which compounded with `format_normal`'s own `hardline`. |
| **#6** | Style reshape | `x = begin\n  …\nend` rewritten as `x =\n  begin\n  …\nend`. | `format_variable_write` unconditionally split block-valued assignments across two lines. |
| **`!@`** | Name rewrite | `def !@` silently rewritten to `def !`. | `extract_node_name` returns Prism's canonical `name` (`:!`), discarding the `@` suffix; the original slice lives on `name_loc`. |

## Before / after highlights

```ruby
# #4: else + ensure no longer duplicates the keyword
begin
  risky
rescue => e
  :e
else
  :ok
ensure
  :final
end   # was: ensure\nensure...\nend\nend

# #3: heredoc + `if` modifier stays on the opener line
scope.push(<<~SQL, type: params[:type]) if params[:type]
  SELECT 1
SQL    # was: SQL if params[:type] — broke heredoc termination

# #2: multi-line def header preserves every inline comment exactly once
def demo(a, # first
         b, # second
         c) # third
  [a, b, c]
end

# #9: chain inside a brace-lambda keeps its local indent
scope :active_in, ->(period) {
  where(active: true)
    .where(last_seen_at: period)  # was: collapsed to col 4
}

# #6: inline `x = begin` stays inline
x = begin
  1
rescue
  2
end  # was: x =\n  begin\n    1\n  ...

# #10: no blank line after `if (… <<~SQL)` terminator
if (sql = <<~SQL)
  SELECT 1
SQL
  execute(sql)
end

# !@ preserves the @ suffix
def !@
  false
end
```

## Changes
- `ext/rfmt/src/format/rule.rs` — `reformat_chain_lines` now skips lines that open a block (`{`, ` do`, `|`).
- `ext/rfmt/src/format/rules/begin.rs` — `format_begin_clause` emitter handles `ElseNode` explicitly; used from both `format_explicit_begin` and `format_implicit_begin_body`.
- `ext/rfmt/src/format/rules/body_end.rs` — multi-line header detection with verbatim source emission + comment-mass-mark-emitted; shared `push_body_and_end` body/end emitter; `line_end_offset` helper.
- `ext/rfmt/src/format/rules/if_unless.rs` — `format_postfix` emits heredoc-containing statements verbatim; `format_normal` strips one trailing newline from the predicate slice; new `statement_contains_heredoc_tail` detector.
- `ext/rfmt/src/format/rules/variable_write.rs` — inline preservation when the block-valued RHS starts on the assignment's own line.
- `lib/rfmt/prism_bridge.rb` — `DefNode` name uses `name_loc.slice` to keep operator `@` suffixes.
- `spec/rails_idioms_round2_spec.rb` — 9 round-trip + idempotence + Prism parse-check tests, one per bug.

## Test plan
- [x] `cargo test --manifest-path ext/rfmt/Cargo.toml --lib` — 127 passed
- [x] `bundle exec rspec` — 128 passed (119 existing + 9 new)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bundle exec rubocop` — clean
- [x] All 25 round-2 synthetic Rails-idiom fixtures pass Prism parse after formatting, and are idempotent.

Supersedes #103 (closed when its base branch was deleted alongside the #102 merge).