### PR TITLE
Fix: orphan comments inside do…end blocks merging with `end`

### DIFF
--- a/ext/rfmt/src/format/rule.rs
+++ b/ext/rfmt/src/format/rule.rs
@@ -217,6 +217,23 @@ pub fn format_comments_before_end(
     }
 
     let mut docs: Vec<Doc> = vec![hardline()];
+    // Preserve the blank line that separated the body's last content from
+    // the first trailing comment. Without this, a construct like
+    //
+    //   def foo
+    //     body
+    //                          <- blank line
+    //     # trailing annotation
+    //   end
+    //
+    // collapses to `body\n# trailing annotation\nend`. Detect the case
+    // heuristically: if the source line immediately above the first
+    // standalone comment is blank, emit an extra hardline.
+    if let Some(first) = standalone_refs.first() {
+        if first.start_line > 1 && is_line_blank(ctx.source(), first.start_line - 1) {
+            docs.push(hardline());
+        }
+    }
     let mut last_end_line: Option<usize> = None;
     let mut indices_to_mark: Vec<usize> = Vec::with_capacity(standalone_refs.len());
 
@@ -297,11 +314,23 @@ pub fn format_remaining_comments(ctx: &mut FormatContext, last_code_line: usize)
     let mut indices_to_mark: Vec<usize> = Vec::with_capacity(comment_refs.len());
 
     for cref in &comment_refs {
-        // Preserve blank lines
+        // Preserve blank lines. On the first iteration we must emit *at
+        // least one* hardline to separate the first remaining comment from
+        // the main document's last token (otherwise an orphan comment whose
+        // `start_line <= last_code_line` would concatenate onto whatever
+        // ended the output — producing e.g. `end# comment…` when a block's
+        // internal comments fall through to this tail handler). Round-tripping
+        // the already-formatted output must still be idempotent, so we
+        // cap the emission at the number of line breaks visible in the
+        // source: 1 for an adjacent comment, N for N-1 blank lines above it.
         let gap = cref.start_line.saturating_sub(last_end_line);
 
-        // Only add newlines if not the first comment or if there's a gap
-        if !is_first || gap > 0 {
+        if is_first {
+            let hardlines_to_emit = gap.max(1);
+            for _ in 0..hardlines_to_emit {
+                docs.push(hardline());
+            }
+        } else if gap > 0 {
             for _ in 0..gap.max(1) {
                 docs.push(hardline());
             }
@@ -497,6 +526,27 @@ pub fn reformat_chain_lines(
     }
 
     Cow::Owned(result)
+}
+
+/// Returns true when the given 1-based `line` in `source` contains only
+/// whitespace (or is empty). Returns false for any line that has code or
+/// a comment.
+fn is_line_blank(source: &str, line: usize) -> bool {
+    let mut current = 1usize;
+    let mut line_start = 0usize;
+    for (i, b) in source.bytes().enumerate() {
+        if current == line {
+            let end = source[i..].find('\n').map_or(source.len(), |n| i + n);
+            return source[line_start..end]
+                .bytes()
+                .all(|b| b == b' ' || b == b'\t' || b == b'\r');
+        }
+        if b == b'\n' {
+            current += 1;
+            line_start = i + 1;
+        }
+    }
+    false
 }
 
 /// Removes at most one trailing `\n` (optionally preceded by a single `\r`)

--- a/ext/rfmt/src/format/rules/call.rs
+++ b/ext/rfmt/src/format/rules/call.rs
@@ -13,9 +13,9 @@ use crate::error::Result;
 use crate::format::context::FormatContext;
 use crate::format::registry::RuleRegistry;
 use crate::format::rule::{
-    format_child, format_leading_comments, format_statements, format_trailing_comment,
-    line_leading_indent, mark_comments_in_range_emitted, reformat_chain_lines,
-    strip_one_trailing_newline, FormatRule,
+    format_child, format_comments_before_end, format_leading_comments, format_statements,
+    format_trailing_comment, line_leading_indent, mark_comments_in_range_emitted,
+    reformat_chain_lines, strip_one_trailing_newline, FormatRule,
 };
 
 /// Rule for formatting method calls.
@@ -249,6 +249,23 @@ fn format_do_end_block(
                 // Skip parameter nodes
             }
         }
+    }
+
+    // Emit any standalone comments between the last body statement and `end`.
+    //
+    // Without this the orphan comments inside a `do…end` block (e.g. the
+    // commented-out config stanzas in a generated `spec_helper.rb`) never
+    // get claimed by any `format_leading_comments` call, fall through to
+    // `format_remaining_comments` at the end of the file, and get emitted
+    // *after* the block's own `end` — producing `end# comment…` with no
+    // separator and dropping the body indent.
+    let comments_before_end = format_comments_before_end(
+        ctx,
+        block_node.location.start_line,
+        block_node.location.end_line,
+    );
+    if !comments_before_end.is_empty() {
+        docs.push(indent(comments_before_end));
     }
 
     // Emit 'end'

--- a/spec/do_end_orphan_comments_spec.rb
+++ b/spec/do_end_orphan_comments_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Rfmt, 'Orphan comments inside do…end blocks' do
+  def idempotent(source)
+    first = Rfmt.format(source)
+    second = Rfmt.format(first)
+    expect(second).to eq(first), "non-idempotent output:\n#{first}"
+    first
+  end
+
+  it 'keeps comments inside the block instead of concatenating them to `end`' do
+    source = <<~RUBY
+      RSpec.configure do |config|
+        config.expect_with :rspec do |expectations|
+          expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+        end
+
+        # The settings below are suggested to provide a good initial experience
+        # with RSpec, but feel free to customize to your heart's content.
+        #   config.filter_run_when_matching :focus
+      end
+    RUBY
+    formatted = idempotent(source)
+
+    # The block's `end` must sit alone — no comment concatenated onto it.
+    expect(formatted).not_to match(/\bend#/)
+    expect(formatted).to match(/^end$/m)
+
+    # The comments must remain *inside* the block, indented one level.
+    expect(formatted).to include('  # The settings below')
+    expect(formatted).to include('  #   config.filter_run_when_matching :focus')
+  end
+
+  it 'preserves the blank line between the last body statement and a trailing comment' do
+    source = <<~RUBY
+      class Foo
+        def bar
+          1
+        end
+
+        # trailing annotation
+      end
+    RUBY
+    expect(idempotent(source)).to eq(source)
+  end
+
+  it 'does not add extra blank lines to file-level trailing comments on successive passes' do
+    source = <<~RUBY
+      class Main
+      end
+
+      # End comment
+    RUBY
+    expect(idempotent(source)).to eq(source)
+  end
+end


### PR DESCRIPTION
## Summary
A `do…end` block body whose body contains only one "real" statement followed by stand-alone comments (e.g. the commented-out `config.filter_run_when_matching :focus` stanzas in a vanilla `RSpec.configure do |config| … end`) emitted:

```ruby
RSpec.configure do |config|
  config.expect_with :rspec do |expectations|
    ...
  end
end# The settings below are suggested to provide a good initial experience
# with RSpec, but feel free to customize to your heart's content.
...
```

- `end` and the first orphan comment **merged onto the same line with no whitespace**
- all subsequent orphan comments **lost their body indent** and landed at column 0

Still syntactically valid Ruby, but obviously wrong aesthetically and confusing in diffs.

## Root cause
Two layers:

1. `format_do_end_block` did not call `format_comments_before_end` for its own range, so stand-alone comments between the last body statement and the block's `end` were never claimed during block emission. (`format_body_end` already does this for def/class/module.)
2. When those orphan comments fell through to `format_remaining_comments` at the file tail, the first-iteration branch silently skipped the leading hardline (`!is_first || gap > 0`), so whenever `gap == 0` the comment concatenated directly onto the preceding token.

## Fix
- **`format_do_end_block`** now calls `format_comments_before_end(block.start_line, block.end_line)` and wraps the result in `indent(...)`, so orphan comments land at body indent inside the block — exactly where the user wrote them.
- **`format_comments_before_end`** now preserves the blank line that separated the body's last content from its first trailing comment (via a small `is_line_blank` source probe). Previously the blank separator was collapsed whenever the first comment was the entry point.
- **`format_remaining_comments`** now always emits at least one hardline for the first comment (gap = 0 → 1 hardline; gap = N → N hardlines), guaranteeing a separator from whatever the main doc emitted last. This is a safety net for any future path that leaves a comment unclaimed.

## Regression tests
`spec/do_end_orphan_comments_spec.rb` (3 cases):
- orphan comments inside a `do…end` block stay inside it, indented one level
- blank line between the body's last statement and a trailing comment survives
- idempotence on re-format for `…end\n\n# comment` tail

## Test plan
- [x] `cargo test --manifest-path ext/rfmt/Cargo.toml --lib` — 127 passed
- [x] `bundle exec rspec` — 131 passed (128 existing + 3 new)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bundle exec rubocop` — clean
- [x] All 50 Rails-idiom fixtures from earlier sweeps remain idempotent (no regression)