### PR TITLE
Fix: chain reformatting leaves multi-line arguments orphaned

### DIFF
--- a/ext/rfmt/src/format/rule.rs
+++ b/ext/rfmt/src/format/rule.rs
@@ -508,8 +508,42 @@ pub fn reformat_chain_lines(
         return Cow::Borrowed(source_text);
     }
 
-    // Build the indented chain with pre-allocated capacity
-    let chain_indent = " ".repeat(base_indent + indent_width);
+    // Determine how much the chain is moving left. Before this pass, every
+    // `.method` line sat at some original "chain indent" (most commonly
+    // aligned under the first receiver's dot). We rewrite those lines to
+    // `base_indent + indent_width` — but that also means any multi-line
+    // *arguments* that lived inside a chain call like `.select( … )` used
+    // to be deeper than the original chain indent, and will now look
+    // orphaned off to the right if we leave them alone:
+    //
+    //     @users = User.left_joins(...)
+    //                 .select(           <- was col 17, becomes col 6
+    //                   'users.*, ' \   <- still at col 19 — orphaned
+    //                 )
+    //                 .having(...)
+    //
+    // Compute the delta between the original chain indent and the new
+    // one, and shift every non-chain continuation line that lives at
+    // (or below) the original chain indent by the same amount. Lines
+    // shallower than the original chain indent (e.g. a heredoc body
+    // whose squiggly indent is measured from the terminator) are left
+    // alone, so we don't accidentally eat through them.
+    let new_chain_indent = base_indent + indent_width;
+    let chain_indent_str = " ".repeat(new_chain_indent);
+
+    let original_chain_indent = lines[1..].iter().find_map(|l| {
+        let t = l.trim_start();
+        if t.starts_with('.') || t.starts_with("&.") {
+            Some(l.len() - t.len())
+        } else {
+            None
+        }
+    });
+
+    let arg_shift = original_chain_indent
+        .map(|orig| orig.saturating_sub(new_chain_indent))
+        .unwrap_or(0);
+
     let mut result = String::with_capacity(source_text.len());
     result.push_str(lines[0].trim_end());
 
@@ -517,8 +551,18 @@ pub fn reformat_chain_lines(
         result.push('\n');
         let trimmed = line.trim();
         if trimmed.starts_with('.') || trimmed.starts_with("&.") {
-            result.push_str(&chain_indent);
+            result.push_str(&chain_indent_str);
             result.push_str(trimmed);
+        } else if arg_shift > 0 && !trimmed.is_empty() {
+            let indent = line.len() - line.trim_start().len();
+            let chain_base = original_chain_indent.unwrap_or(0);
+            if indent >= chain_base {
+                let new_indent = indent - arg_shift;
+                result.push_str(&" ".repeat(new_indent));
+                result.push_str(line.trim_start());
+            } else {
+                result.push_str(line);
+            }
         } else {
             // Non-chain continuation (e.g., heredoc content): preserve as-is
             result.push_str(line);

--- a/spec/chain_multiline_args_spec.rb
+++ b/spec/chain_multiline_args_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Rfmt, 'Chain reformatting with multi-line arguments' do
+  def idempotent(source)
+    first = Rfmt.format(source)
+    second = Rfmt.format(first)
+    expect(second).to eq(first), "non-idempotent output:\n#{first}"
+    first
+  end
+
+  it 'shifts multi-line args inside a chain call down with the chain itself' do
+    source = <<~RUBY
+      module Api
+        class UsersController
+          def ranking
+            @users = User.left_joins(articles: :article_likes)
+                         .group('users.id')
+                         .select(
+                           'users.*, ' \\
+                           'COUNT(CASE WHEN articles.status = 1 THEN article_likes.id END) AS received_likes_count'
+                         )
+                         .having('received_likes_count > 0')
+                         .order('received_likes_count DESC')
+                         .limit(5)
+          end
+        end
+      end
+    RUBY
+    formatted = idempotent(source)
+
+    # After chain reformat, `.select(`, the `)`, and each chain method should
+    # all sit at the same column (base_indent + indent_width = 8), and the
+    # args inside `.select(...)` should be exactly one indent deeper (10).
+    expect(formatted).to include("        .select(\n          'users.*, '")
+    expect(formatted).to match(/^        \)\n {8}\.having/m)
+    expect(formatted).to include("        .having('received_likes_count > 0')")
+    expect(formatted).to include('        .limit(5)')
+  end
+
+  it 'does not shift non-chain lines when no chain reformat happens' do
+    source = <<~RUBY
+      foo(
+        arg1,
+        arg2
+      )
+    RUBY
+    expect(idempotent(source)).to eq(source)
+  end
+
+  it 'preserves heredoc body indent when reformatting a tail chain' do
+    source = <<~RUBY
+      class Q
+        def call
+          query = <<~SQL
+            SELECT *
+          SQL
+          query.squish
+        end
+      end
+    RUBY
+    formatted = idempotent(source)
+    expect(formatted).to include("      SELECT *\n    SQL")
+  end
+end


### PR DESCRIPTION
## Summary
When `reformat_chain_lines` (PR #100's aligned → indented rewrite) fires on a multi-line method chain that contains a call with **multi-line arguments** such as `.select(...)`, only the `.method` lines get moved. Anything inside the call's argument list — strings split across lines, the trailing `)`, etc. — stays at its original column:

```ruby
# before
@users = User.left_joins(articles: :article_likes)
             .group('users.id')
             .select(
               'users.*, ' \
               'COUNT(CASE WHEN articles.status = 1 THEN article_likes.id END) AS received_likes_count'
             )
             .having('received_likes_count > 0')

# after (bug)
@users = User.left_joins(articles: :article_likes)
  .group('users.id')
  .select(
               'users.*, ' \
               'COUNT(CASE WHEN articles.status = 1 THEN article_likes.id END) AS received_likes_count'
             )
  .having('received_likes_count > 0')
```

The chain body sits at column 6 but the `.select(...)` arguments still float at column 15, and the closing `)` lands at column 13 — visually orphaned and trailing off to the right.

## Root cause
`reformat_chain_lines` rewrites every `.method` line to `" " * (base_indent + indent_width)` but preserves every non-chain continuation line as-is. When the original chain sat at a deeper indent than the new one (aligned → indented is *always* this direction), anything aligned relative to the original chain — function arguments, closing parens, etc. — is left stranded.

## Fix
Before rewriting, capture the *original* chain indent (the leading whitespace of the first `.method` line) and compute `arg_shift = original_chain_indent − new_chain_indent`. For every non-chain continuation line whose leading indent is **at or deeper than** the original chain indent, shift its leading whitespace by `arg_shift`. Lines shallower than the original chain indent — a squiggly-heredoc body measured against its own terminator, for instance — are left alone so we don't eat through their content.

```ruby
# after (this PR)
@users = User.left_joins(articles: :article_likes)
  .group('users.id')
  .select(
    'users.*, ' \
    'COUNT(CASE WHEN articles.status = 1 THEN article_likes.id END) AS received_likes_count'
  )
  .having('received_likes_count > 0')
```

## Regression tests
`spec/chain_multiline_args_spec.rb` (3 cases):
- multi-line `.select(...)` args shift with the chain
- no-op when there is no chain reformat (paren-only call)
- heredoc body indent is preserved when the chain reformat applies to a tail `.squish`/`.strip` etc.

## Test plan
- [x] `cargo test --manifest-path ext/rfmt/Cargo.toml --lib` — 127 passed
- [x] `bundle exec rspec` — 134 passed (131 existing + 3 new)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bundle exec rubocop` — clean
- [x] All 50 Rails-idiom fixtures from earlier sweeps remain idempotent