### PR TITLE
Add standalone rfmt LSP server

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,9 @@ PATH
     rfmt (1.6.3)
       diff-lcs (~> 1.5)
       diffy (~> 3.4)
+      language_server-protocol (~> 3.17)
+      parallel (~> 1.24)
+      prism (~> 1.6)
       rb_sys (~> 0.9.120)
       thor (~> 1.3)
 

--- a/README.md
+++ b/README.md
@@ -361,7 +361,35 @@ end
 
 ## Editor Integration
 
-rfmt integrates with editors through [Ruby LSP](https://shopify.github.io/ruby-lsp/). For detailed setup instructions, see [Editor Integration Guide](docs/editors.md).
+rfmt can integrate with editors in two ways:
+
+- Standalone LSP: run `rfmt-lsp` directly from your editor. This works well for single
+  Ruby scripts or projects without a Gemfile.
+- Ruby LSP add-on: use rfmt as the formatter inside
+  [Ruby LSP](https://shopify.github.io/ruby-lsp/).
+
+For detailed setup instructions, see [Editor Integration Guide](docs/editors.md).
+
+### Standalone LSP
+
+After installing rfmt, configure your editor's Ruby language server command to `rfmt-lsp`.
+
+```bash
+gem install rfmt
+rfmt-lsp
+```
+
+Example Helix configuration:
+
+```toml
+[language-server.rfmt]
+command = "rfmt-lsp"
+
+[[language]]
+name = "ruby"
+language-servers = ["rfmt"]
+auto-format = true
+```
 
 ### VSCode (Quick Start)
 

--- a/docs/editors.md
+++ b/docs/editors.md
@@ -1,6 +1,11 @@
 # Editor Integration
 
-rfmt integrates with editors through [Ruby LSP](https://shopify.github.io/ruby-lsp/).
+rfmt integrates with editors either as a standalone LSP server or as a formatter
+inside [Ruby LSP](https://shopify.github.io/ruby-lsp/).
+
+Use the standalone LSP when you want formatting for a single Ruby script or a
+project without a Gemfile. Use the Ruby LSP add-on when your editor already runs
+Ruby LSP and you want rfmt as one of its formatter backends.
 
 ## Prerequisites
 
@@ -9,7 +14,87 @@ rfmt integrates with editors through [Ruby LSP](https://shopify.github.io/ruby-l
    gem install rfmt
    ```
 
-2. Ensure Ruby LSP is configured in your editor
+2. Configure either `rfmt-lsp` directly or Ruby LSP in your editor
+
+## Standalone LSP
+
+The `rfmt-lsp` executable starts a stdio LSP server that provides document
+formatting. It does not require a project Gemfile or Ruby LSP. The server reads
+`.rfmt.yml` from the workspace root, parent directories, or your home directory,
+matching the normal rfmt configuration discovery behavior.
+
+### Helix
+
+Add to `~/.config/helix/languages.toml`:
+
+```toml
+[language-server.rfmt]
+command = "rfmt-lsp"
+
+[[language]]
+name = "ruby"
+language-servers = ["rfmt"]
+auto-format = true
+```
+
+### Neovim
+
+With `nvim-lspconfig`, register a small custom server:
+
+```lua
+local configs = require("lspconfig.configs")
+local lspconfig = require("lspconfig")
+
+if not configs.rfmt then
+  configs.rfmt = {
+    default_config = {
+      cmd = { "rfmt-lsp" },
+      filetypes = { "ruby" },
+      root_dir = lspconfig.util.root_pattern(".rfmt.yml", ".git"),
+      single_file_support = true,
+    },
+  }
+end
+
+lspconfig.rfmt.setup({})
+```
+
+### Emacs eglot
+
+```elisp
+(require 'eglot)
+
+(add-to-list 'eglot-server-programs
+             '(ruby-mode . ("rfmt-lsp")))
+
+(add-hook 'ruby-mode-hook 'eglot-ensure)
+```
+
+### Zed
+
+Add to `settings.json`:
+
+```json
+{
+  "languages": {
+    "Ruby": {
+      "format_on_save": "on"
+    }
+  },
+  "lsp": {
+    "rfmt": {
+      "binary": {
+        "path": "rfmt-lsp"
+      }
+    }
+  }
+}
+```
+
+## Ruby LSP Add-on
+
+The Ruby LSP add-on is useful when your editor already uses Ruby LSP for
+diagnostics, navigation, and other Ruby language features.
 
 ## VSCode
 

--- a/exe/rfmt-lsp
+++ b/exe/rfmt-lsp
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$VERBOSE = nil unless ENV['RFMT_VERBOSE']
+
+require 'rfmt/lsp/server'
+
+exit Rfmt::LSP::Server.new.run

--- a/lib/rfmt/lsp.rb
+++ b/lib/rfmt/lsp.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require_relative 'lsp/document_store'
+require_relative 'lsp/formatter'
+require_relative 'lsp/message_io'
+require_relative 'lsp/server'
+require_relative 'lsp/uri'
+require_relative 'lsp/workspace'

--- a/lib/rfmt/lsp/document_store.rb
+++ b/lib/rfmt/lsp/document_store.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Rfmt
+  module LSP
+    class DocumentStore
+      def initialize
+        @documents = {}
+      end
+
+      def open(uri, text)
+        @documents[uri] = text
+      end
+
+      def change(uri, text)
+        @documents[uri] = text
+      end
+
+      def close(uri)
+        @documents.delete(uri)
+      end
+
+      def source_for(uri)
+        @documents[uri]
+      end
+    end
+  end
+end

--- a/lib/rfmt/lsp/formatter.rb
+++ b/lib/rfmt/lsp/formatter.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rfmt'
+
+module Rfmt
+  module LSP
+    class Formatter
+      def self.format_edits(source)
+        formatted = source.empty? ? "\n" : Rfmt.format(source)
+        return [] if formatted == source
+
+        [
+          {
+            range: full_document_range(source),
+            newText: formatted
+          }
+        ]
+      rescue Rfmt::Error
+        []
+      end
+
+      def self.full_document_range(source)
+        lines = source.split("\n", -1)
+
+        {
+          start: { line: 0, character: 0 },
+          end: {
+            line: lines.length - 1,
+            character: lines.last.length
+          }
+        }
+      end
+    end
+  end
+end

--- a/lib/rfmt/lsp/formatter.rb
+++ b/lib/rfmt/lsp/formatter.rb
@@ -20,6 +20,8 @@ module Rfmt
       end
 
       def self.full_document_range(source)
+        return { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } } if source.empty?
+
         lines = source.split("\n", -1)
 
         {

--- a/lib/rfmt/lsp/message_io.rb
+++ b/lib/rfmt/lsp/message_io.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module Rfmt
+  module LSP
+    # Reads and writes LSP JSON-RPC messages over an IO pair.
+    class MessageIO
+      HEADER_SEPARATOR = "\r\n\r\n"
+      CONTENT_LENGTH = /\AContent-Length:\s*(\d+)\z/i
+
+      def initialize(input: $stdin, output: $stdout)
+        @input = input
+        @output = output
+      end
+
+      def read_message
+        headers = read_headers
+        return nil if headers.nil?
+
+        content_length = headers.fetch('content-length').to_i
+        JSON.parse(@input.read(content_length))
+      end
+
+      def write_message(payload)
+        body = JSON.generate(payload)
+        @output.write("Content-Length: #{body.bytesize}#{HEADER_SEPARATOR}#{body}")
+        @output.flush if @output.respond_to?(:flush)
+      end
+
+      private
+
+      def read_headers
+        headers = {}
+
+        loop do
+          line = @input.gets
+          return nil if line.nil?
+
+          line = line.chomp
+          line = line.delete_suffix("\r")
+          break if line.empty?
+
+          match = CONTENT_LENGTH.match(line)
+          headers['content-length'] = match[1] if match
+        end
+
+        headers.fetch('content-length')
+        headers
+      rescue KeyError
+        nil
+      end
+    end
+  end
+end

--- a/lib/rfmt/lsp/server.rb
+++ b/lib/rfmt/lsp/server.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require 'language_server/protocol'
+require 'rfmt/version'
+
+require_relative 'document_store'
+require_relative 'formatter'
+require_relative 'message_io'
+require_relative 'uri'
+require_relative 'workspace'
+
+module Rfmt
+  module LSP
+    class Server
+      TEXT_DOCUMENT_SYNC_FULL = 1
+      METHOD_NOT_FOUND = -32_601
+      INTERNAL_ERROR = -32_603
+
+      def initialize(input: $stdin, output: $stdout)
+        @io = MessageIO.new(input: input, output: output)
+        @documents = DocumentStore.new
+        @workspace = Workspace.new
+        @shutdown_requested = false
+      end
+
+      def run
+        while (message = @io.read_message)
+          return @shutdown_requested ? 0 : 1 if handle_message(message) == :exit
+        end
+
+        0
+      end
+
+      def handle_message(message)
+        method = message['method']
+        id = message['id']
+        params = message['params'] || {}
+
+        case method
+        when 'initialize'
+          handle_initialize(id, params)
+        when 'initialized'
+          nil
+        when 'textDocument/didOpen'
+          handle_did_open(params)
+        when 'textDocument/didChange'
+          handle_did_change(params)
+        when 'textDocument/didClose'
+          handle_did_close(params)
+        when 'textDocument/formatting'
+          handle_formatting(id, params)
+        when 'shutdown'
+          handle_shutdown(id)
+        when 'exit'
+          :exit
+        else
+          respond_error(id, METHOD_NOT_FOUND, "Method not found: #{method}") if id
+        end
+      rescue StandardError => e
+        respond_error(id, INTERNAL_ERROR, e.message) if id
+      end
+
+      private
+
+      def handle_initialize(id, params)
+        @workspace.configure(params)
+
+        respond(id, {
+                  capabilities: {
+                    documentFormattingProvider: true,
+                    textDocumentSync: TEXT_DOCUMENT_SYNC_FULL
+                  },
+                  serverInfo: {
+                    name: 'rfmt',
+                    version: Rfmt::VERSION
+                  }
+                })
+      end
+
+      def handle_did_open(params)
+        text_document = params.fetch('textDocument')
+        @documents.open(text_document.fetch('uri'), text_document.fetch('text'))
+      end
+
+      def handle_did_change(params)
+        uri = params.fetch('textDocument').fetch('uri')
+        change = Array(params['contentChanges']).last
+        return unless change&.key?('text')
+
+        @documents.change(uri, change.fetch('text'))
+      end
+
+      def handle_did_close(params)
+        uri = params.fetch('textDocument').fetch('uri')
+        @documents.close(uri)
+      end
+
+      def handle_formatting(id, params)
+        uri = params.fetch('textDocument').fetch('uri')
+        source = @documents.source_for(uri) || read_file_source(uri)
+        edits = if source
+                  @workspace.with_root_for(uri) { Formatter.format_edits(source) }
+                else
+                  []
+                end
+
+        respond(id, edits)
+      end
+
+      def handle_shutdown(id)
+        @shutdown_requested = true
+        respond(id, nil)
+      end
+
+      def read_file_source(uri)
+        path = URI.file_uri_to_path(uri)
+        return nil unless path && File.file?(path)
+
+        File.read(path)
+      end
+
+      def respond(id, result)
+        @io.write_message({
+                            jsonrpc: '2.0',
+                            id: id,
+                            result: result
+                          })
+      end
+
+      def respond_error(id, code, message)
+        @io.write_message({
+                            jsonrpc: '2.0',
+                            id: id,
+                            error: {
+                              code: code,
+                              message: message
+                            }
+                          })
+      end
+    end
+  end
+end

--- a/lib/rfmt/lsp/server.rb
+++ b/lib/rfmt/lsp/server.rb
@@ -36,31 +36,57 @@ module Rfmt
         id = message['id']
         params = message['params'] || {}
 
-        case method
-        when 'initialize'
-          handle_initialize(id, params)
-        when 'initialized'
-          nil
-        when 'textDocument/didOpen'
-          handle_did_open(params)
-        when 'textDocument/didChange'
-          handle_did_change(params)
-        when 'textDocument/didClose'
-          handle_did_close(params)
-        when 'textDocument/formatting'
-          handle_formatting(id, params)
-        when 'shutdown'
-          handle_shutdown(id)
-        when 'exit'
-          :exit
-        else
-          respond_error(id, METHOD_NOT_FOUND, "Method not found: #{method}") if id
-        end
+        dispatch_message(method, id, params)
       rescue StandardError => e
         respond_error(id, INTERNAL_ERROR, e.message) if id
       end
 
       private
+
+      def dispatch_message(method, id, params)
+        if request_handler?(method)
+          dispatch_request(method, id, params)
+        else
+          dispatch_notification(method, params) || respond_method_not_found(id, method)
+        end
+      end
+
+      def request_handler?(method)
+        %w[initialize textDocument/formatting shutdown].include?(method)
+      end
+
+      def dispatch_request(method, id, params)
+        case method
+        when 'initialize'
+          handle_initialize(id, params)
+        when 'textDocument/formatting'
+          handle_formatting(id, params)
+        when 'shutdown'
+          handle_shutdown(id)
+        end
+      end
+
+      def dispatch_notification(method, params)
+        case method
+        when 'initialized'
+          true
+        when 'textDocument/didOpen'
+          handle_did_open(params)
+          true
+        when 'textDocument/didChange'
+          handle_did_change(params)
+          true
+        when 'textDocument/didClose'
+          handle_did_close(params)
+          true
+        when 'exit'
+          :exit
+        end
+      end
+
+      def respond_method_not_found(id, method)
+        respond_error(id, METHOD_NOT_FOUND, "Method not found: #{method}") if id
+      end
 
       def handle_initialize(id, params)
         @workspace.configure(params)

--- a/lib/rfmt/lsp/uri.rb
+++ b/lib/rfmt/lsp/uri.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'uri'
+
+module Rfmt
+  module LSP
+    module URI
+      module_function
+
+      def file_uri_to_path(uri)
+        parsed = ::URI.parse(uri)
+        return nil unless parsed.scheme == 'file'
+
+        percent_decode(parsed.path)
+      rescue ::URI::InvalidURIError
+        nil
+      end
+
+      def path_to_file_uri(path)
+        "file://#{percent_encode(File.expand_path(path))}"
+      end
+
+      def percent_decode(value)
+        value.gsub(/%[0-9A-Fa-f]{2}/) { |match| [match[1..].to_i(16)].pack('C') }
+      end
+
+      def percent_encode(value)
+        value.bytes.map do |byte|
+          char = byte.chr
+          char.match?(/[A-Za-z0-9._~\/-]/) ? char : format('%%%02X', byte)
+        end.join
+      end
+    end
+  end
+end

--- a/lib/rfmt/lsp/uri.rb
+++ b/lib/rfmt/lsp/uri.rb
@@ -27,7 +27,7 @@ module Rfmt
       def percent_encode(value)
         value.bytes.map do |byte|
           char = byte.chr
-          char.match?(/[A-Za-z0-9._~\/-]/) ? char : format('%%%02X', byte)
+          char.match?(%r{[A-Za-z0-9._~/-]}) ? char : format('%%%02X', byte)
         end.join
       end
     end

--- a/lib/rfmt/lsp/workspace.rb
+++ b/lib/rfmt/lsp/workspace.rb
@@ -30,11 +30,11 @@ module Rfmt
         existing_root(File.dirname(path))
       end
 
-      def with_root_for(uri)
+      def with_root_for(uri, &block)
         root = root_for(uri)
-        return yield unless root
+        return block.call unless root
 
-        Dir.chdir(root) { yield }
+        Dir.chdir(root, &block)
       end
 
       private

--- a/lib/rfmt/lsp/workspace.rb
+++ b/lib/rfmt/lsp/workspace.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'pathname'
+
+require_relative 'uri'
+
+module Rfmt
+  module LSP
+    class Workspace
+      def initialize
+        @roots = []
+      end
+
+      def configure(params)
+        @roots = workspace_folder_roots(params)
+        root_uri = params['rootUri']
+        @roots << URI.file_uri_to_path(root_uri) if root_uri
+        @roots = @roots.compact.map { |root| File.expand_path(root) }.uniq
+      end
+
+      def root_for(uri)
+        path = URI.file_uri_to_path(uri)
+        return existing_root(@roots.first) unless path
+
+        matching_root = @roots
+                        .select { |root| path_inside?(path, root) }
+                        .max_by(&:length)
+        return existing_root(matching_root) if matching_root
+
+        existing_root(File.dirname(path))
+      end
+
+      def with_root_for(uri)
+        root = root_for(uri)
+        return yield unless root
+
+        Dir.chdir(root) { yield }
+      end
+
+      private
+
+      def workspace_folder_roots(params)
+        Array(params['workspaceFolders']).filter_map do |folder|
+          URI.file_uri_to_path(folder['uri'])
+        end
+      end
+
+      def path_inside?(path, root)
+        relative = Pathname.new(path).relative_path_from(Pathname.new(root)).to_s
+        relative == '.' || !relative.start_with?('..')
+      rescue ArgumentError
+        false
+      end
+
+      def existing_root(root)
+        return nil unless root && File.directory?(root)
+
+        root
+      end
+    end
+  end
+end

--- a/rfmt.gemspec
+++ b/rfmt.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
     'CHANGELOG.md'
   ]
   spec.bindir = 'exe'
-  spec.executables = ['rfmt', 'rfmt-lsp']
+  spec.executables = %w[rfmt rfmt-lsp]
   spec.require_paths = ['lib']
   spec.extensions = ['ext/rfmt/extconf.rb']
 

--- a/rfmt.gemspec
+++ b/rfmt.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   # Explicitly list files to avoid including compiled artifacts (.bundle, .so)
   spec.files = Dir[
+    'exe/*',
     'lib/**/*.rb',
     'ext/**/*.{rb,rs,toml}',
     'Cargo.toml',
@@ -33,12 +34,15 @@ Gem::Specification.new do |spec|
     'CHANGELOG.md'
   ]
   spec.bindir = 'exe'
-  spec.executables = ['rfmt']
+  spec.executables = ['rfmt', 'rfmt-lsp']
   spec.require_paths = ['lib']
   spec.extensions = ['ext/rfmt/extconf.rb']
 
   spec.add_dependency 'diff-lcs', '~> 1.5'
   spec.add_dependency 'diffy', '~> 3.4'
+  spec.add_dependency 'language_server-protocol', '~> 3.17'
+  spec.add_dependency 'parallel', '~> 1.24'
+  spec.add_dependency 'prism', '~> 1.6'
   spec.add_dependency 'rb_sys', '~> 0.9.120'
   spec.add_dependency 'thor', '~> 1.3'
 end

--- a/spec/rfmt/lsp/executable_spec.rb
+++ b/spec/rfmt/lsp/executable_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'rfmt-lsp executable' do
+  it 'is packaged as an executable' do
+    executable = File.expand_path('../../../exe/rfmt-lsp', __dir__)
+
+    expect(File.file?(executable)).to eq(true)
+    expect(File.executable?(executable)).to eq(true)
+    expect(Gem::Specification.load('rfmt.gemspec').executables).to include('rfmt-lsp')
+  end
+end

--- a/spec/rfmt/lsp/server_spec.rb
+++ b/spec/rfmt/lsp/server_spec.rb
@@ -1,0 +1,212 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'stringio'
+require 'tmpdir'
+
+require 'spec_helper'
+require 'rfmt/lsp/server'
+
+RSpec.describe Rfmt::LSP::Server do
+  def build_server
+    output = StringIO.new
+    server = described_class.new(input: StringIO.new, output: output)
+    [server, output]
+  end
+
+  def read_messages(output)
+    io = StringIO.new(output.string)
+    messages = []
+
+    loop do
+      header = io.gets
+      break unless header
+
+      length = header[/Content-Length:\s*(\d+)/i, 1].to_i
+      io.gets
+      messages << JSON.parse(io.read(length))
+    end
+
+    messages
+  end
+
+  def file_uri(path)
+    Rfmt::LSP::URI.path_to_file_uri(path)
+  end
+
+  describe '#handle_message' do
+    it 'returns formatting capabilities on initialize' do
+      server, output = build_server
+
+      server.handle_message({
+                              'jsonrpc' => '2.0',
+                              'id' => 1,
+                              'method' => 'initialize',
+                              'params' => {}
+                            })
+
+      response = read_messages(output).first
+      expect(response['id']).to eq(1)
+      expect(response.dig('result', 'capabilities', 'documentFormattingProvider')).to eq(true)
+      expect(response.dig('result', 'capabilities', 'textDocumentSync')).to eq(1)
+      expect(response.dig('result', 'serverInfo', 'name')).to eq('rfmt')
+    end
+
+    it 'formats an opened document with a full-document text edit' do
+      server, output = build_server
+      uri = file_uri('/tmp/test.rb')
+
+      server.handle_message({
+                              'jsonrpc' => '2.0',
+                              'method' => 'textDocument/didOpen',
+                              'params' => {
+                                'textDocument' => {
+                                  'uri' => uri,
+                                  'text' => "class Foo\ndef bar\n42\nend\nend\n"
+                                }
+                              }
+                            })
+      server.handle_message({
+                              'jsonrpc' => '2.0',
+                              'id' => 2,
+                              'method' => 'textDocument/formatting',
+                              'params' => {
+                                'textDocument' => { 'uri' => uri },
+                                'options' => {}
+                              }
+                            })
+
+      response = read_messages(output).last
+      edit = response['result'].first
+      expect(edit['range']).to eq({
+                                    'start' => { 'line' => 0, 'character' => 0 },
+                                    'end' => { 'line' => 5, 'character' => 0 }
+                                  })
+      expect(edit['newText']).to include("  def bar\n")
+      expect(edit['newText']).to include("    42\n")
+    end
+
+    it 'returns no edits when formatting fails' do
+      server, output = build_server
+      uri = file_uri('/tmp/broken.rb')
+
+      server.handle_message({
+                              'jsonrpc' => '2.0',
+                              'method' => 'textDocument/didOpen',
+                              'params' => {
+                                'textDocument' => {
+                                  'uri' => uri,
+                                  'text' => 'def foo('
+                                }
+                              }
+                            })
+      server.handle_message({
+                              'jsonrpc' => '2.0',
+                              'id' => 3,
+                              'method' => 'textDocument/formatting',
+                              'params' => {
+                                'textDocument' => { 'uri' => uri },
+                                'options' => {}
+                              }
+                            })
+
+      expect(read_messages(output).last['result']).to eq([])
+    end
+
+    it 'formats an empty document as a newline' do
+      server, output = build_server
+      uri = file_uri('/tmp/empty.rb')
+
+      server.handle_message({
+                              'jsonrpc' => '2.0',
+                              'method' => 'textDocument/didOpen',
+                              'params' => {
+                                'textDocument' => {
+                                  'uri' => uri,
+                                  'text' => ''
+                                }
+                              }
+                            })
+      server.handle_message({
+                              'jsonrpc' => '2.0',
+                              'id' => 4,
+                              'method' => 'textDocument/formatting',
+                              'params' => {
+                                'textDocument' => { 'uri' => uri },
+                                'options' => {}
+                              }
+                            })
+
+      edit = read_messages(output).last['result'].first
+      expect(edit['range']).to eq({
+                                    'start' => { 'line' => 0, 'character' => 0 },
+                                    'end' => { 'line' => 0, 'character' => 0 }
+                                  })
+      expect(edit['newText']).to eq("\n")
+    end
+
+    it 'uses the workspace root when discovering rfmt config' do
+      Dir.mktmpdir do |root|
+        File.write(File.join(root, '.rfmt.yml'), <<~YAML)
+          version: "1.0"
+          formatting:
+            indent_width: 4
+        YAML
+        path = File.join(root, 'test.rb')
+        uri = file_uri(path)
+        server, output = build_server
+
+        server.handle_message({
+                                'jsonrpc' => '2.0',
+                                'id' => 1,
+                                'method' => 'initialize',
+                                'params' => { 'rootUri' => file_uri(root) }
+                              })
+        server.handle_message({
+                                'jsonrpc' => '2.0',
+                                'method' => 'textDocument/didOpen',
+                                'params' => {
+                                  'textDocument' => {
+                                    'uri' => uri,
+                                    'text' => "class Foo\ndef bar\n42\nend\nend\n"
+                                  }
+                                }
+                              })
+        server.handle_message({
+                                'jsonrpc' => '2.0',
+                                'id' => 5,
+                                'method' => 'textDocument/formatting',
+                                'params' => {
+                                  'textDocument' => { 'uri' => uri },
+                                  'options' => {}
+                                }
+                              })
+
+        edit = read_messages(output).last['result'].first
+        expect(edit['newText']).to include("    def bar\n")
+        expect(edit['newText']).to include("        42\n")
+      end
+    end
+
+    it 'handles shutdown and exit' do
+      server, output = build_server
+
+      server.handle_message({
+                              'jsonrpc' => '2.0',
+                              'id' => 6,
+                              'method' => 'shutdown',
+                              'params' => nil
+                            })
+      result = server.handle_message({
+                                       'jsonrpc' => '2.0',
+                                       'method' => 'exit',
+                                       'params' => nil
+                                     })
+
+      response = read_messages(output).last
+      expect(response['id']).to eq(6)
+      expect(response['result']).to be_nil
+      expect(result).to eq(:exit)
+    end
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a standalone `rfmt-lsp` executable so editors can use rfmt formatting directly through LSP, without requiring Ruby LSP or a project Gemfile.

Fixes #107

## Changes

- Add a stdio LSP server with document formatting support
- Reuse the existing `Rfmt.format(source)` formatter pipeline
- Resolve formatting config from the LSP workspace root so `.rfmt.yml` works in editors
- Package runtime dependencies needed for `gem install rfmt` usage
- Document standalone LSP editor setup

## Testing

CI passed:

- Lint / RuboCop
- Ruby test suite and coverage
- Ruby/Rust matrix tests
- Ruby 4.0 workflow
- GitGuardian security check

Added RSpec coverage for:

- LSP initialize capabilities
- document formatting edits
- syntax-error fallback with no edits
- empty-document formatting
- workspace-root config discovery
- executable packaging
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cdead7b9-6030-4baa-b614-0fa9211a5a9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cdead7b9-6030-4baa-b614-0fa9211a5a9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

