### PR TITLE
chore: set up GitHub Sponsors (FUNDING.yml + README badge)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: sorafujitani


### PR DESCRIPTION
## Description

Set up the GitHub Sponsors entry points for this repository:
- Add `.github/FUNDING.yml` so the repository header shows the ♡ Sponsor button.
- Add a Sponsor badge to the README badge row.

## Motivation

Give visitors a clear path to support the maintainer, both from the repository header and the README.

## Changes

- Add `.github/FUNDING.yml` (`github: sorafujitani`)
- Add Sponsor badge to `README.md`

## Type of Change

- [x] Documentation update

## Testing

- [x] No code changes (metadata + docs only). Will confirm the Sponsor button and README badge render after merge.

## Additional Notes

The Sponsors profile (`github.com/sponsors/sorafujitani`) is already published, so both the button and the badge link correctly once this is merged.