### PR TITLE
Roadmap Phase 2: output validation guard and self-hosted corpus check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
     - name: Run Ruby tests
       run: bundle exec rspec
 
+    - name: Run corpus check
+      run: bundle exec ruby scripts/corpus_check.rb
+
     - name: Run Rust tests
       run: cargo test --manifest-path ext/rfmt/Cargo.toml
 

--- a/lib/rfmt.rb
+++ b/lib/rfmt.rb
@@ -23,7 +23,12 @@ module Rfmt
 
     # Step 2: Format in Rust
     # Pass both source and AST to enable source extraction fallback
-    format_code(source, prism_json)
+    formatted = format_code(source, prism_json)
+
+    # Guard against formatter bugs: never emit syntactically invalid Ruby
+    validate_output!(formatted)
+
+    formatted
   rescue PrismBridge::ParseError => e
     # Re-raise with more context
     raise Error, "Failed to parse Ruby code: #{e.message}"
@@ -33,6 +38,17 @@ module Rfmt
   rescue StandardError => e
     raise Error, "Unexpected error during formatting: #{e.class}: #{e.message}"
   end
+
+  def self.validate_output!(formatted)
+    result = Prism.parse(formatted)
+    return if result.success?
+
+    error = result.errors.first
+    raise ValidationError, 'Formatter produced syntactically invalid output ' \
+                           "(this is a bug in rfmt, not in your code): #{error.message} " \
+                           "at line #{error.location.start_line}"
+  end
+  private_class_method :validate_output!
 
   # Format a Ruby file
   # @param path [String] Path to Ruby file

--- a/scripts/corpus_check.rb
+++ b/scripts/corpus_check.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+require 'prism'
+require_relative '../lib/rfmt'
+
+module CorpusCheck
+  CORPUS_GLOBS = ['lib/**/*.rb', 'spec/**/*.rb', 'scripts/**/*.rb'].freeze
+
+  # Files with known formatter bugs, skipped with a warning (exit stays 0).
+  KNOWN_FAILURES = [
+    'lib/rfmt/prism_bridge.rb' # comments inside a do..end block are re-emitted after the block on every pass (idempotency bug)
+  ].freeze
+
+  # Structural AST equality that ignores source positions, so that a
+  # reformatted file can be compared against its original.
+  module AstComparator
+    module_function
+
+    # Some semantics live only in flags plus an operator token, not in
+    # deconstruct_keys values: `a.b` vs `a&.b`, `1..5` vs `1...5`. Prism
+    # exposes no public flags reader, so compare these tokens by slice.
+    OPERATOR_LOC_KEYS = %i[operator_loc call_operator_loc].freeze
+    # Regex options (/x/i vs /x/) live in the closing token.
+    REGEXP_NODES = [Prism::RegularExpressionNode, Prism::InterpolatedRegularExpressionNode].freeze
+
+    def equivalent?(left, right)
+      equivalent_values?(left, right)
+    end
+
+    def equivalent_nodes?(left, right)
+      return false unless left.instance_of?(right.class)
+
+      left_keys = left.deconstruct_keys(nil)
+      right_keys = right.deconstruct_keys(nil)
+
+      left_keys.all? do |key, left_value|
+        right_value = right_keys[key]
+        next true if key == :node_id
+        next slice_pair_equal?(left_value, right_value) if OPERATOR_LOC_KEYS.include?(key)
+        next slice_pair_equal?(left_value, right_value) if key == :closing_loc && REGEXP_NODES.include?(left.class)
+        next true if location_pair?(left_value, right_value)
+
+        equivalent_values?(left_value, right_value)
+      end
+    end
+
+    def slice_pair_equal?(left, right)
+      return left == right unless left.is_a?(Prism::Location) && right.is_a?(Prism::Location)
+
+      left.slice == right.slice
+    end
+
+    def equivalent_values?(left, right)
+      case left
+      when Prism::Node
+        right.is_a?(Prism::Node) && equivalent_nodes?(left, right)
+      when Array
+        right.is_a?(Array) &&
+          left.size == right.size &&
+          left.zip(right).all? { |l, r| equivalent_values?(l, r) }
+      else
+        left == right
+      end
+    end
+
+    def location_pair?(left, right)
+      [left, right].any? { |value| value.is_a?(Prism::Location) } &&
+        [left, right].all? { |value| value.is_a?(Prism::Location) || value.nil? }
+    end
+  end
+
+  class Runner
+    def initialize(globs: CORPUS_GLOBS, root: File.expand_path('..', __dir__))
+      @globs = globs
+      @root = root
+      @checked = 0
+      @passed = 0
+      @skipped = 0
+      @failed = 0
+    end
+
+    def run
+      Dir.chdir(@root) do
+        files = @globs.flat_map { |glob| Dir[glob] }.uniq.sort
+        stale = KNOWN_FAILURES - files
+        unless stale.empty?
+          puts "FAIL: KNOWN_FAILURES entries not in corpus: #{stale.join(', ')}"
+          @failed += stale.size
+        end
+        files.each { |path| check_file(path) }
+      end
+
+      puts "\nchecked: #{@checked}, passed: #{@passed}, skipped: #{@skipped}, failed: #{@failed}"
+      @failed.zero? ? 0 : 1
+    end
+
+    private
+
+    def check_file(path)
+      source = File.read(path)
+      source_result = Prism.parse(source)
+      unless source_result.success?
+        warn "SKIP (source does not parse): #{path}"
+        @skipped += 1
+        return
+      end
+
+      @checked += 1
+      failures = property_failures(path, source, source_result)
+      record(path, failures)
+    rescue StandardError => e
+      @checked += 1
+      record(path, ["error during check: #{e.class}: #{e.message}"])
+    end
+
+    # Known failures still run every property so a fixed file surfaces as
+    # XPASS instead of rotting in the list forever.
+    def record(path, failures)
+      known = KNOWN_FAILURES.include?(path)
+      if failures.empty? && known
+        @failed += 1
+        puts "XPASS: #{path}: all properties pass; remove it from KNOWN_FAILURES"
+      elsif failures.empty?
+        @passed += 1
+      elsif known
+        @skipped += 1
+        warn "SKIP (known failure): #{path}"
+      else
+        @failed += 1
+        failures.each { |message| puts "FAIL: #{path}: #{message}" }
+      end
+    end
+
+    def property_failures(_path, source, source_result)
+      # The guard in Rfmt.format raises before invalid output can reach us
+      begin
+        formatted = Rfmt.format(source)
+      rescue Rfmt::ValidationError => e
+        return ["syntactic validity: #{e.message}"]
+      end
+
+      formatted_result = Prism.parse(formatted)
+
+      failures = []
+      failures << idempotency_failure(formatted)
+      unless AstComparator.equivalent?(source_result.value, formatted_result.value)
+        failures << 'AST equivalence: formatted output changed program structure'
+      end
+      # Comments are not part of the AST, so a dropped comment passes every other property
+      if source_result.comments.size != formatted_result.comments.size
+        failures << "comment preservation: #{source_result.comments.size} comments in source, " \
+                    "#{formatted_result.comments.size} in output"
+      end
+      failures.compact
+    end
+
+    def idempotency_failure(formatted)
+      reformatted = Rfmt.format(formatted)
+      return nil if reformatted == formatted
+
+      "idempotency: second format pass changed output\n#{first_diff_excerpt(formatted, reformatted)}"
+    end
+
+    def first_diff_excerpt(formatted, reformatted)
+      formatted_lines = formatted.lines
+      reformatted_lines = reformatted.lines
+      index = formatted_lines.zip(reformatted_lines).index { |a, b| a != b } || formatted_lines.size
+      [
+        "    line #{index + 1}:",
+        "    - #{formatted_lines[index].to_s.chomp}",
+        "    + #{reformatted_lines[index].to_s.chomp}"
+      ].join("\n")
+    end
+  end
+end
+
+exit CorpusCheck::Runner.new.run if __FILE__ == $PROGRAM_NAME

--- a/spec/corpus_check_spec.rb
+++ b/spec/corpus_check_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'prism'
+require_relative '../scripts/corpus_check'
+
+RSpec.describe CorpusCheck::AstComparator do
+  def parse(source)
+    Prism.parse(source).value
+  end
+
+  describe '.equivalent?' do
+    it 'accepts semantically identical sources with different quoting' do
+      single = parse("x = 'hello'\n")
+      double = parse(%(x = "hello"\n))
+
+      expect(described_class.equivalent?(single, double)).to be true
+    end
+
+    it 'accepts identical sources with different layout' do
+      compact = parse('def foo(a, b) = a + b')
+      expanded = parse("def foo(a, b) = a + b\n")
+
+      expect(described_class.equivalent?(compact, expanded)).to be true
+    end
+
+    it 'rejects a dropped statement' do
+      full = parse("x = 1\ny = 2\n")
+      dropped = parse("x = 1\n")
+
+      expect(described_class.equivalent?(full, dropped)).to be false
+    end
+
+    it 'rejects a changed literal' do
+      original = parse("x = 1\n")
+      changed = parse("x = 2\n")
+
+      expect(described_class.equivalent?(original, changed)).to be false
+    end
+
+    it 'rejects safe navigation downgraded to a plain call' do
+      safe = parse("a&.b\n")
+      plain = parse("a.b\n")
+
+      expect(described_class.equivalent?(safe, plain)).to be false
+    end
+
+    it 'rejects an exclusive range changed to inclusive' do
+      exclusive = parse("1...5\n")
+      inclusive = parse("1..5\n")
+
+      expect(described_class.equivalent?(exclusive, inclusive)).to be false
+    end
+
+    it 'rejects dropped regexp options' do
+      insensitive = parse("/x/i\n")
+      sensitive = parse("/x/\n")
+
+      expect(described_class.equivalent?(insensitive, sensitive)).to be false
+    end
+  end
+end

--- a/spec/output_validation_spec.rb
+++ b/spec/output_validation_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Rfmt, '.format output validation' do
+  context 'when the formatter produces invalid Ruby' do
+    before do
+      allow(described_class).to receive(:format_code).and_return('def broken(')
+    end
+
+    it 'raises Rfmt::Error mentioning invalid output' do
+      expect do
+        described_class.format('x = 1')
+      end.to raise_error(Rfmt::Error, /invalid output/)
+    end
+  end
+
+  context 'without stubbing' do
+    it 'formats valid code normally' do
+      result = described_class.format('x = 1')
+
+      expect(result).to include('x = 1')
+    end
+  end
+end


### PR DESCRIPTION
Implements Phase 2 (verification net) of #110.

## Changes

**Output validation guard** (`lib/rfmt.rb`). `Rfmt.format` now re-parses its own output with Prism and raises `Rfmt::ValidationError` if the formatter produced syntactically invalid Ruby. The error message states explicitly that this is an rfmt bug, not a user-code problem. Because both the CLI and the LSP route through `Rfmt.format`, the CLI can no longer overwrite a valid source file with broken output, and the LSP falls back to returning no edit. This closes the highest-risk gap from the audit: silent destruction of user code by a formatting-rule bug.

**Self-hosted corpus check** (`scripts/corpus_check.rb`, CI step). Runs the formatter over this repo's own Ruby files (`lib/`, `spec/`, `scripts/`; currently 45 files) and asserts four properties per file:

1. Syntactic validity of the output
2. Idempotency: `format(format(x)) == format(x)`
3. AST equivalence between input and output, via recursive `deconstruct_keys` comparison that ignores source locations but compares operator tokens by slice — Prism encodes some semantics only in flags plus an operator token, so without this `a.b` vs `a&.b`, `1..5` vs `1...5`, and `/x/i` vs `/x/` would wrongly pass as equivalent (covered by specs)
4. Comment-count preservation: comments are not part of the AST, so a dropped comment would pass every other property

`KNOWN_FAILURES` entries still run every property: a fixed file reports XPASS and fails the run until removed from the list, and stale paths are rejected, so the list cannot rot.

## Bug found by the new check

The corpus check immediately caught a real formatter bug: comments inside `do..end` blocks are duplicated after the block on every pass, so formatting never converges. Filed as #112 and registered in `KNOWN_FAILURES`.

## Performance

The guard adds one Prism parse per format call. Measured in-process over the `lib/` corpus (17 files x 5 rounds, arm64 macOS):

| | avg per file |
|---|---|
| before | 5.49 ms |
| after | 5.51 ms |

+0.3%, within run-to-run noise.

## Verification

- `bundle exec rspec`: 150 examples, 0 failures (9 new)
- `bundle exec ruby scripts/corpus_check.rb`: checked 45, passed 44, 1 known-failure skip, exit 0
- RuboCop clean on all touched files
