### PR TITLE
Fix comment duplication in verbatim source extraction paths

### DIFF
--- a/ext/rfmt/src/format/rules/if_unless.rs
+++ b/ext/rfmt/src/format/rules/if_unless.rs
@@ -14,7 +14,7 @@ use crate::format::context::FormatContext;
 use crate::format::registry::RuleRegistry;
 use crate::format::rule::{
     format_leading_comments, format_statements, format_trailing_comment,
-    strip_one_trailing_newline, FormatRule,
+    mark_comments_in_range_emitted, strip_one_trailing_newline, FormatRule,
 };
 
 /// Rule for formatting if conditionals.
@@ -115,8 +115,13 @@ fn format_postfix(
     // the modifier is already baked into the source text right where
     // Ruby expects it.
     if let Some(statements) = node.children.get(1) {
-        if let Some(source_text) = ctx.extract_source(statements) {
-            if statement_contains_heredoc_tail(source_text) {
+        if let Some(source_text) = ctx.extract_source(statements).map(str::to_string) {
+            mark_comments_in_range_emitted(
+                ctx,
+                statements.location.start_line,
+                statements.location.end_line,
+            );
+            if statement_contains_heredoc_tail(&source_text) {
                 docs.push(text(source_text.trim_end_matches('\n').to_string()));
 
                 let trailing = format_trailing_comment(ctx, node.location.end_line);
@@ -193,6 +198,11 @@ fn format_ternary(node: &Node, ctx: &mut FormatContext) -> Result<Doc> {
     if let Some(statements) = node.children.get(1) {
         if let Some(source_text) = ctx.extract_source(statements) {
             docs.push(text(source_text.trim()));
+            mark_comments_in_range_emitted(
+                ctx,
+                statements.location.start_line,
+                statements.location.end_line,
+            );
         }
     }
 
@@ -203,6 +213,11 @@ fn format_ternary(node: &Node, ctx: &mut FormatContext) -> Result<Doc> {
         if let Some(else_statements) = else_node.children.first() {
             if let Some(source_text) = ctx.extract_source(else_statements) {
                 docs.push(text(source_text.trim()));
+                mark_comments_in_range_emitted(
+                    ctx,
+                    else_statements.location.start_line,
+                    else_statements.location.end_line,
+                );
             }
         }
     }

--- a/ext/rfmt/src/format/rules/loops.rs
+++ b/ext/rfmt/src/format/rules/loops.rs
@@ -12,7 +12,8 @@ use crate::error::Result;
 use crate::format::context::FormatContext;
 use crate::format::registry::RuleRegistry;
 use crate::format::rule::{
-    format_leading_comments, format_statements, format_trailing_comment, FormatRule,
+    format_leading_comments, format_statements, format_trailing_comment,
+    mark_comments_in_range_emitted, FormatRule,
 };
 
 /// Rule for formatting while loops.
@@ -80,6 +81,7 @@ fn format_postfix_while_until(node: &Node, ctx: &mut FormatContext, keyword: &st
     // Extract from source for postfix form
     if let Some(source_text) = ctx.extract_source(node) {
         docs.push(text(source_text));
+        mark_comments_in_range_emitted(ctx, node.location.start_line, node.location.end_line);
     }
 
     // Trailing comment

--- a/ext/rfmt/src/format/rules/variable_write.rs
+++ b/ext/rfmt/src/format/rules/variable_write.rs
@@ -13,7 +13,7 @@ use crate::format::context::FormatContext;
 use crate::format::registry::RuleRegistry;
 use crate::format::rule::{
     format_child, format_leading_comments, format_trailing_comment, line_leading_indent,
-    reformat_chain_lines, strip_one_trailing_newline, FormatRule,
+    mark_comments_in_range_emitted, reformat_chain_lines, strip_one_trailing_newline, FormatRule,
 };
 
 /// Rule for formatting local variable write expressions.
@@ -66,6 +66,7 @@ fn format_variable_write(
             // No value: fallback to source extraction
             if let Some(source_text) = ctx.extract_source(node) {
                 docs.push(text(source_text.to_string()));
+                mark_comments_in_range_emitted(ctx, start_line, end_line);
             }
             let trailing = format_trailing_comment(ctx, end_line);
             if !trailing.is_empty() {
@@ -132,11 +133,24 @@ fn format_variable_write(
                 );
                 let trimmed = strip_one_trailing_newline(reformatted.trim_start());
                 docs.push(text(trimmed.to_string()));
+                // The extracted text carries any interior comments verbatim
+                // (e.g. inside a `do…end` block); without marking them they
+                // get re-emitted at EOF by format_remaining_comments.
+                mark_comments_in_range_emitted(
+                    ctx,
+                    value.location.start_line,
+                    value.location.end_line,
+                );
             }
         } else {
             // Simple value: extract from source trimmed
             if let Some(source_text) = ctx.extract_source(value) {
                 docs.push(text(source_text.trim().to_string()));
+                mark_comments_in_range_emitted(
+                    ctx,
+                    value.location.start_line,
+                    value.location.end_line,
+                );
             }
         }
     }

--- a/scripts/corpus_check.rb
+++ b/scripts/corpus_check.rb
@@ -7,9 +7,7 @@ module CorpusCheck
   CORPUS_GLOBS = ['lib/**/*.rb', 'spec/**/*.rb', 'scripts/**/*.rb'].freeze
 
   # Files with known formatter bugs, skipped with a warning (exit stays 0).
-  KNOWN_FAILURES = [
-    'lib/rfmt/prism_bridge.rb' # comments inside a do..end block are re-emitted after the block on every pass (idempotency bug)
-  ].freeze
+  KNOWN_FAILURES = [].freeze
 
   # Structural AST equality that ignores source positions, so that a
   # reformatted file can be compared against its original.

--- a/spec/comment_emission_invariant_spec.rb
+++ b/spec/comment_emission_invariant_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Every construct whose rule emits verbatim source must mark the swept
+# comments as emitted, or they duplicate at EOF and grow on every pass.
+RSpec.describe Rfmt, 'comment emission invariant' do
+  CASES = {
+    'variable write with do..end block' => <<~RUBY,
+      comments = result.comments.map do |comment|
+        # inner note
+        line = loc.end_line - 1
+      end
+
+      JSON.generate({ ast: 1 })
+    RUBY
+    'modifier if' => <<~RUBY,
+      foo(
+        # inner note
+        bar
+      ) if condition
+    RUBY
+    'postfix while' => <<~RUBY,
+      process(
+        # inner note
+        item
+      ) while queue.any?
+    RUBY
+    'ternary with multiline branch' => <<~RUBY
+      x = cond ? foo(
+        # inner note
+        bar
+      ) : baz
+    RUBY
+  }.freeze
+
+  CASES.each do |name, source|
+    context "with #{name}" do
+      it 'emits each comment exactly once' do
+        expect(Rfmt.format(source).scan('# inner note').size).to eq(1)
+      end
+
+      it 'is idempotent' do
+        first = Rfmt.format(source)
+
+        expect(Rfmt.format(first)).to eq(first)
+      end
+    end
+  end
+end

--- a/spec/do_end_comment_duplication_spec.rb
+++ b/spec/do_end_comment_duplication_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Rfmt, 'Comment duplication in do…end blocks (#112)' do
+  let(:source) do
+    <<~RUBY
+      comments = result.comments.map do |comment|
+        # first line of a long explanation
+        # second line of the explanation
+        line = loc.end_line - 1
+        { text: loc.slice, position: "leading" } # trailing comment here
+      end
+
+      JSON.generate({ ast: 1 })
+    RUBY
+  end
+
+  it 'emits each block-interior comment exactly once' do
+    formatted = Rfmt.format(source)
+
+    expect(formatted.scan('# first line of a long explanation').size).to eq(1)
+    expect(formatted.scan('# second line of the explanation').size).to eq(1)
+    expect(formatted.scan('# trailing comment here').size).to eq(1)
+  end
+
+  it 'is idempotent' do
+    first = Rfmt.format(source)
+    second = Rfmt.format(first)
+
+    expect(second).to eq(first)
+  end
+end


### PR DESCRIPTION
Fixes #112. First phase of the ruby-prism migration plan (#110 Phase 3): make the corpus check fully green before the parser migration starts, so it serves as an unqualified safety net.

## Root cause

Comment attachment in the Rust formatter is positional: every comment index must land in `FormatContext.emitted_comment_indices`, and anything unmarked is flushed at end of file by `format_remaining_comments`. Rules that emit multi-line verbatim source sweep comments into their output; if they do not also mark those comments, the same text is emitted a second time at EOF, and each subsequent pass compounds it.

The originally suspected site (the do..end block path in `call.rs`) turned out to mark correctly. The actual hole for #112 was `variable_write.rs`: `x = call do ... end` extracts the whole multi-line value verbatim without marking. A review pass over every `extract_source` site then found the same defect in three more rules, each with a confirmed non-convergent reproduction:

- modifier `if`/`unless` (`if_unless.rs`, statement extraction)
- postfix `while`/`until` (`loops.rs`, whole-node extraction)
- ternary then/else branches (`if_unless.rs`)

All four sites now mark the extracted line range, following the existing idiom from `fallback.rs`. Range marking excludes the final line, so a trailing comment on the closing line is still handled by `format_trailing_comment` (no swallowed comments; verified against leading, interior, and trailing placements).

## Commit order

1. `test:` failing spec reproducing #112 (committed first, confirmed red)
2. `fix:` the variable-write marking, `KNOWN_FAILURES` emptied
3. `fix:` the three sibling sites plus a construct-table invariant spec (`spec/comment_emission_invariant_spec.rb`) asserting emit-once and idempotency across all four shapes

## Verification

- rspec: 160 examples, 0 failures (10 new)
- corpus check: checked 47, passed 47, skipped 0 — `KNOWN_FAILURES` is now empty and the XPASS mechanism keeps it honest
- cargo test 127 passed; clippy `-D warnings` clean
- Real CLI on the #112 reproduction: second pass byte-identical to the first
