### PR TITLE
Roadmap Phase 3-6: switch Rfmt.format to native parsing (12x in-process speedup)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
     - name: Run corpus check
       run: bundle exec ruby scripts/corpus_check.rb
 
+    - name: Run differential check
+      run: bundle exec ruby scripts/differential_check.rb
+
     - name: Run Rust tests
       run: cargo test --manifest-path ext/rfmt/Cargo.toml
 

--- a/ext/rfmt/src/error/mod.rs
+++ b/ext/rfmt/src/error/mod.rs
@@ -8,6 +8,15 @@ pub enum RfmtError {
     #[error("Prism integration error: {0}")]
     PrismError(String),
 
+    // Message-only kinds: lib/rfmt.rb rewrites these into its public
+    // exception classes by their [Rfmt::...] prefix, so Display must not
+    // add any wrapper text around the message.
+    #[error("{0}")]
+    ParseError(String),
+
+    #[error("{0}")]
+    ValidationError(String),
+
     #[error("Format error: {0}")]
     FormatError(String),
 
@@ -33,6 +42,8 @@ impl RfmtError {
     pub fn to_magnus_error(&self, ruby: &Ruby) -> MagnusError {
         let exception_class = match self {
             RfmtError::PrismError(_) => "PrismError",
+            RfmtError::ParseError(_) => "ParseError",
+            RfmtError::ValidationError(_) => "ValidationError",
             RfmtError::FormatError(_) => "FormatError",
             RfmtError::UnsupportedFeature { .. } => "UnsupportedFeature",
             RfmtError::ConfigError { .. } => "ConfigError",

--- a/ext/rfmt/src/lib.rs
+++ b/ext/rfmt/src/lib.rs
@@ -12,7 +12,7 @@ use policy::SecurityPolicy;
 use config::Config;
 use format::Formatter;
 use magnus::{function, prelude::*, Error, Ruby};
-use parser::{PrismAdapter, RubyParser};
+use parser::{NativeAdapter, PrismAdapter, RubyParser};
 
 fn format_ruby_code(ruby: &Ruby, source: String, json: String) -> Result<String, Error> {
     let policy = SecurityPolicy::default();
@@ -23,6 +23,29 @@ fn format_ruby_code(ruby: &Ruby, source: String, json: String) -> Result<String,
 
     let parser = PrismAdapter::new();
     let ast = parser.parse(&json).map_err(|e| e.to_magnus_error(ruby))?;
+
+    let config = Config::discover().map_err(|e| e.to_magnus_error(ruby))?;
+    let formatter = Formatter::new(config);
+
+    let formatted = formatter
+        .format(&source, &ast)
+        .map_err(|e| e.to_magnus_error(ruby))?;
+
+    Ok(formatted)
+}
+
+// Temporary for the prism migration: same flow as format_ruby_code with only
+// the parse path swapped, so differential_check.rb isolates converter bugs.
+// Deleted in phase 7 when NativeAdapter becomes the only path.
+fn format_ruby_code_native(ruby: &Ruby, source: String) -> Result<String, Error> {
+    let policy = SecurityPolicy::default();
+
+    policy
+        .validate_source_size(&source)
+        .map_err(|e| e.to_magnus_error(ruby))?;
+
+    let parser = NativeAdapter::new();
+    let ast = parser.parse(&source).map_err(|e| e.to_magnus_error(ruby))?;
 
     let config = Config::discover().map_err(|e| e.to_magnus_error(ruby))?;
     let formatter = Formatter::new(config);
@@ -54,6 +77,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     let module = ruby.define_module("Rfmt")?;
 
     module.define_singleton_method("format_code", function!(format_ruby_code, 2))?;
+    module.define_singleton_method("format_code_native", function!(format_ruby_code_native, 1))?;
     module.define_singleton_method("parse_to_json", function!(parse_to_json, 1))?;
     module.define_singleton_method("rust_version", function!(rust_version, 0))?;
 

--- a/ext/rfmt/src/lib.rs
+++ b/ext/rfmt/src/lib.rs
@@ -6,6 +6,7 @@ pub mod format;
 mod logging;
 pub mod parser;
 mod policy;
+pub mod validation;
 
 use policy::SecurityPolicy;
 
@@ -14,7 +15,32 @@ use format::Formatter;
 use magnus::{function, prelude::*, Error, Ruby};
 use parser::{NativeAdapter, PrismAdapter, RubyParser};
 
-fn format_ruby_code(ruby: &Ruby, source: String, json: String) -> Result<String, Error> {
+fn format_ruby_code(ruby: &Ruby, source: String) -> Result<String, Error> {
+    let policy = SecurityPolicy::default();
+
+    policy
+        .validate_source_size(&source)
+        .map_err(|e| e.to_magnus_error(ruby))?;
+
+    let parser = NativeAdapter::new();
+    let ast = parser.parse(&source).map_err(|e| e.to_magnus_error(ruby))?;
+
+    let config = Config::discover().map_err(|e| e.to_magnus_error(ruby))?;
+    let formatter = Formatter::new(config);
+
+    let formatted = formatter
+        .format(&source, &ast)
+        .map_err(|e| e.to_magnus_error(ruby))?;
+
+    validation::validate_output(&formatted).map_err(|e| e.to_magnus_error(ruby))?;
+
+    Ok(formatted)
+}
+
+// Temporary for the prism migration: the pre-switchover pipeline (Ruby Prism
+// JSON in, no output validation), kept so differential_check.rb can compare
+// it against the native path. Deleted in phase 7.
+fn format_ruby_code_legacy(ruby: &Ruby, source: String, json: String) -> Result<String, Error> {
     let policy = SecurityPolicy::default();
 
     policy
@@ -34,33 +60,10 @@ fn format_ruby_code(ruby: &Ruby, source: String, json: String) -> Result<String,
     Ok(formatted)
 }
 
-// Temporary for the prism migration: same flow as format_ruby_code with only
-// the parse path swapped, so differential_check.rb isolates converter bugs.
-// Deleted in phase 7 when NativeAdapter becomes the only path.
-fn format_ruby_code_native(ruby: &Ruby, source: String) -> Result<String, Error> {
-    let policy = SecurityPolicy::default();
-
-    policy
-        .validate_source_size(&source)
-        .map_err(|e| e.to_magnus_error(ruby))?;
-
-    let parser = NativeAdapter::new();
-    let ast = parser.parse(&source).map_err(|e| e.to_magnus_error(ruby))?;
-
-    let config = Config::discover().map_err(|e| e.to_magnus_error(ruby))?;
-    let formatter = Formatter::new(config);
-
-    let formatted = formatter
-        .format(&source, &ast)
-        .map_err(|e| e.to_magnus_error(ruby))?;
-
-    Ok(formatted)
-}
-
-/// Parse Ruby source code and return JSON AST representation
+/// Parse Ruby source code and return the internal AST representation
 /// This is useful for debugging and integration testing
 fn parse_to_json(ruby: &Ruby, source: String) -> Result<String, Error> {
-    let parser = PrismAdapter::new();
+    let parser = NativeAdapter::new();
     let ast = parser.parse(&source).map_err(|e| e.to_magnus_error(ruby))?;
 
     Ok(format!("{:#?}", ast))
@@ -76,8 +79,8 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
 
     let module = ruby.define_module("Rfmt")?;
 
-    module.define_singleton_method("format_code", function!(format_ruby_code, 2))?;
-    module.define_singleton_method("format_code_native", function!(format_ruby_code_native, 1))?;
+    module.define_singleton_method("format_code", function!(format_ruby_code, 1))?;
+    module.define_singleton_method("format_code_legacy", function!(format_ruby_code_legacy, 2))?;
     module.define_singleton_method("parse_to_json", function!(parse_to_json, 1))?;
     module.define_singleton_method("rust_version", function!(rust_version, 0))?;
 

--- a/ext/rfmt/src/parser/native_adapter.rs
+++ b/ext/rfmt/src/parser/native_adapter.rs
@@ -43,7 +43,9 @@ impl RubyParser for NativeAdapter {
             })
             .collect();
         if !errors.is_empty() {
-            return Err(RfmtError::PrismError(format!(
+            // ParseError so lib/rfmt.rb surfaces it as Rfmt::Error
+            // "Failed to parse Ruby code: ..." (PrismBridge parity).
+            return Err(RfmtError::ParseError(format!(
                 "Parse errors:\n{}",
                 errors.join("\n")
             )));

--- a/ext/rfmt/src/validation.rs
+++ b/ext/rfmt/src/validation.rs
@@ -1,0 +1,69 @@
+//! Output guard: never return syntactically invalid Ruby to the caller.
+//! Moved here from lib/rfmt.rb's validate_output! at the phase-6 switchover.
+
+use crate::error::{Result, RfmtError};
+
+pub fn validate_output(formatted: &str) -> Result<()> {
+    let bytes = formatted.as_bytes();
+    let parse_result = ruby_prism::parse(bytes);
+
+    let Some(error) = parse_result.errors().next() else {
+        return Ok(());
+    };
+
+    let line = 1 + bytes[..error.location().start_offset()]
+        .iter()
+        .filter(|&&b| b == b'\n')
+        .count();
+    Err(RfmtError::ValidationError(format!(
+        "Formatter produced syntactically invalid output (this is a bug in rfmt, not in your code): {} at line {}",
+        error.message(),
+        line
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_valid_ruby() {
+        assert!(validate_output("x = 1\n").is_ok());
+    }
+
+    #[test]
+    fn rejects_invalid_ruby_with_validation_error() {
+        let err = validate_output("def broken(\n").unwrap_err();
+
+        match err {
+            RfmtError::ValidationError(message) => {
+                assert!(
+                    message.starts_with(
+                        "Formatter produced syntactically invalid output (this is a bug in rfmt, not in your code): "
+                    ),
+                    "unexpected message: {message}"
+                );
+                assert!(
+                    message.contains(" at line 1"),
+                    "unexpected message: {message}"
+                );
+            }
+            other => panic!("expected ValidationError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reports_the_line_of_the_first_error() {
+        let err = validate_output("x = 1\ny = 2\ndef broken(\n").unwrap_err();
+
+        match err {
+            RfmtError::ValidationError(message) => {
+                assert!(
+                    message.contains(" at line 3"),
+                    "unexpected message: {message}"
+                );
+            }
+            other => panic!("expected ValidationError, got {other:?}"),
+        }
+    }
+}

--- a/lib/rfmt.rb
+++ b/lib/rfmt.rb
@@ -39,6 +39,21 @@ module Rfmt
     raise Error, "Unexpected error during formatting: #{e.class}: #{e.message}"
   end
 
+  # Temporary for the prism migration: same flow as .format minus the
+  # PrismBridge JSON step, so differential_check.rb can compare the two
+  # parse paths. Deleted in phase 7.
+  def self.format_native(source)
+    formatted = format_code_native(source)
+
+    validate_output!(formatted)
+
+    formatted
+  rescue RfmtError
+    raise
+  rescue StandardError => e
+    raise Error, "Unexpected error during formatting: #{e.class}: #{e.message}"
+  end
+
   def self.validate_output!(formatted)
     result = Prism.parse(formatted)
     return if result.success?

--- a/lib/rfmt.rb
+++ b/lib/rfmt.rb
@@ -26,8 +26,6 @@ module Rfmt
   # @return [String] Formatted Ruby code
   def self.format(source)
     format_code(source)
-  rescue RfmtError
-    raise
   rescue StandardError => e
     raise wrap_native_error(e)
   end
@@ -79,6 +77,8 @@ module Rfmt
   # @return [String] AST representation
   def self.parse(source)
     parse_to_json(source)
+  rescue StandardError => e
+    raise wrap_native_error(e)
   end
 
   # Configuration management

--- a/lib/rfmt.rb
+++ b/lib/rfmt.rb
@@ -14,56 +14,49 @@ module Rfmt
   # AST validation errors
   class ValidationError < RfmtError; end
 
+  # Rust reports errors as plain StandardError with a [Rfmt::<kind>] prefix;
+  # these two kinds map onto the public exception classes.
+  NATIVE_PARSE_ERROR_PREFIX = '[Rfmt::ParseError] '
+  NATIVE_VALIDATION_ERROR_PREFIX = '[Rfmt::ValidationError] '
+  private_constant :NATIVE_PARSE_ERROR_PREFIX, :NATIVE_VALIDATION_ERROR_PREFIX
+
   # Format Ruby source code
+  # Parsing and output validation both happen natively in Rust
   # @param source [String] Ruby source code to format
   # @return [String] Formatted Ruby code
   def self.format(source)
-    # Step 1: Parse with Prism (Ruby side)
+    format_code(source)
+  rescue RfmtError
+    raise
+  rescue StandardError => e
+    raise wrap_native_error(e)
+  end
+
+  def self.wrap_native_error(error)
+    message = error.message
+    if message.start_with?(NATIVE_PARSE_ERROR_PREFIX)
+      Error.new("Failed to parse Ruby code: #{message.delete_prefix(NATIVE_PARSE_ERROR_PREFIX)}")
+    elsif message.start_with?(NATIVE_VALIDATION_ERROR_PREFIX)
+      ValidationError.new(message.delete_prefix(NATIVE_VALIDATION_ERROR_PREFIX))
+    else
+      Error.new("Unexpected error during formatting: #{error.class}: #{message}")
+    end
+  end
+  private_class_method :wrap_native_error
+
+  # Temporary for the prism migration: the pre-switchover pipeline
+  # (PrismBridge JSON round-trip), kept so differential_check.rb can compare
+  # it against the native .format. Deleted in phase 7.
+  def self.format_legacy(source)
     prism_json = PrismBridge.parse(source)
-
-    # Step 2: Format in Rust
-    # Pass both source and AST to enable source extraction fallback
-    formatted = format_code(source, prism_json)
-
-    # Guard against formatter bugs: never emit syntactically invalid Ruby
-    validate_output!(formatted)
-
-    formatted
+    format_code_legacy(source, prism_json)
   rescue PrismBridge::ParseError => e
-    # Re-raise with more context
     raise Error, "Failed to parse Ruby code: #{e.message}"
   rescue RfmtError
-    # Rust side errors are re-raised as-is to preserve error details
     raise
   rescue StandardError => e
     raise Error, "Unexpected error during formatting: #{e.class}: #{e.message}"
   end
-
-  # Temporary for the prism migration: same flow as .format minus the
-  # PrismBridge JSON step, so differential_check.rb can compare the two
-  # parse paths. Deleted in phase 7.
-  def self.format_native(source)
-    formatted = format_code_native(source)
-
-    validate_output!(formatted)
-
-    formatted
-  rescue RfmtError
-    raise
-  rescue StandardError => e
-    raise Error, "Unexpected error during formatting: #{e.class}: #{e.message}"
-  end
-
-  def self.validate_output!(formatted)
-    result = Prism.parse(formatted)
-    return if result.success?
-
-    error = result.errors.first
-    raise ValidationError, 'Formatter produced syntactically invalid output ' \
-                           "(this is a bug in rfmt, not in your code): #{error.message} " \
-                           "at line #{error.location.start_line}"
-  end
-  private_class_method :validate_output!
 
   # Format a Ruby file
   # @param path [String] Path to Ruby file
@@ -85,8 +78,7 @@ module Rfmt
   # @param source [String] Ruby source code
   # @return [String] AST representation
   def self.parse(source)
-    prism_json = PrismBridge.parse(source)
-    parse_to_json(prism_json)
+    parse_to_json(source)
   end
 
   # Configuration management

--- a/scripts/differential_check.rb
+++ b/scripts/differential_check.rb
@@ -4,9 +4,9 @@ require 'prism'
 require_relative '../lib/rfmt'
 require_relative 'corpus_check'
 
-# Temporary for the prism migration: proves Rfmt.format_native emits
-# byte-identical output to Rfmt.format across the corpus. Deleted in
-# phase 7 together with format_native.
+# Temporary for the prism migration: proves the native Rfmt.format emits
+# byte-identical output to the pre-switchover Rfmt.format_legacy across the
+# corpus. Deleted in phase 7 together with format_legacy.
 module DifferentialCheck
   CORPUS_GLOBS = (CorpusCheck::CORPUS_GLOBS + ['ext/rfmt/tests/fixtures/parity/*.rb']).freeze
 
@@ -107,8 +107,8 @@ module DifferentialCheck
     end
 
     def compare(path, source)
-      legacy = Rfmt.format(source)
-      native = Rfmt.format_native(source)
+      legacy = Rfmt.format_legacy(source)
+      native = Rfmt.format(source)
 
       diff = DiffReporter.unified_diff(legacy, native)
       if diff.nil?

--- a/scripts/differential_check.rb
+++ b/scripts/differential_check.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require 'prism'
+require_relative '../lib/rfmt'
+require_relative 'corpus_check'
+
+# Temporary for the prism migration: proves Rfmt.format_native emits
+# byte-identical output to Rfmt.format across the corpus. Deleted in
+# phase 7 together with format_native.
+module DifferentialCheck
+  CORPUS_GLOBS = (CorpusCheck::CORPUS_GLOBS + ['ext/rfmt/tests/fixtures/parity/*.rb']).freeze
+
+  module DiffReporter
+    MAX_DIFF_LINES = 40
+
+    module_function
+
+    def unified_diff(legacy, native, limit: MAX_DIFF_LINES)
+      return nil if legacy == native
+
+      legacy_lines = legacy.lines
+      native_lines = native.lines
+      first = common_prefix_size(legacy_lines, native_lines)
+      last_legacy, last_native = trim_common_suffix(legacy_lines, native_lines, first)
+
+      hunk = ["@@ -#{first + 1},#{last_legacy - first + 1} +#{first + 1},#{last_native - first + 1} @@"]
+      hunk += changed_slice(legacy_lines, first, last_legacy).map { |line| render('-', line) }
+      hunk += changed_slice(native_lines, first, last_native).map { |line| render('+', line) }
+      return hunk.join("\n") if hunk.size <= limit
+
+      "#{hunk.first(limit).join("\n")}\n... (#{hunk.size - limit} more diff lines truncated)"
+    end
+
+    # Ruby wraps a negative end index around, so an empty range must be
+    # returned explicitly (one side purely inserting lines hits this).
+    def changed_slice(lines, first, last)
+      return [] if last < first
+
+      lines[first..last]
+    end
+
+    def render(sign, line)
+      return "#{sign}#{line.chomp}" if line.end_with?("\n")
+
+      "#{sign}#{line}\n\\ No newline at end of file"
+    end
+
+    def common_prefix_size(left, right)
+      size = 0
+      size += 1 while size < left.size && size < right.size && left[size] == right[size]
+      size
+    end
+
+    def trim_common_suffix(left, right, prefix_size)
+      last_left = left.size - 1
+      last_right = right.size - 1
+      while last_left >= prefix_size && last_right >= prefix_size && left[last_left] == right[last_right]
+        last_left -= 1
+        last_right -= 1
+      end
+      [last_left, last_right]
+    end
+  end
+
+  class Runner
+    def initialize(globs: CORPUS_GLOBS, root: File.expand_path('..', __dir__))
+      @globs = globs
+      @root = root
+      @checked = 0
+      @matched = 0
+      @skipped = 0
+      @mismatched = 0
+      @errored = 0
+    end
+
+    def run
+      Dir.chdir(@root) do
+        # A glob matching nothing means the safety net silently shrank
+        # (e.g. the parity fixtures moved), so it fails instead of passing.
+        @globs.each do |glob|
+          next unless Dir[glob].empty?
+
+          @errored += 1
+          puts "ERROR: corpus glob matched no files: #{glob}"
+        end
+        files = @globs.flat_map { |glob| Dir[glob] }.uniq.sort
+        files.each { |path| check_file(path) }
+      end
+
+      puts "\nchecked: #{@checked}, matched: #{@matched}, skipped: #{@skipped}, " \
+           "mismatched: #{@mismatched}, errored: #{@errored}"
+      @checked.positive? && @mismatched.zero? && @errored.zero? ? 0 : 1
+    end
+
+    private
+
+    def check_file(path)
+      source = File.read(path)
+      unless Prism.parse(source).success?
+        warn "SKIP (source does not parse): #{path}"
+        @skipped += 1
+        return
+      end
+
+      @checked += 1
+      compare(path, source)
+    end
+
+    def compare(path, source)
+      legacy = Rfmt.format(source)
+      native = Rfmt.format_native(source)
+
+      diff = DiffReporter.unified_diff(legacy, native)
+      if diff.nil?
+        @matched += 1
+      else
+        @mismatched += 1
+        puts "MISMATCH: #{path}\n#{diff}"
+      end
+    rescue StandardError => e
+      @errored += 1
+      puts "ERROR: #{path}: #{e.class}: #{e.message}"
+    end
+  end
+end
+
+exit DifferentialCheck::Runner.new.run if __FILE__ == $PROGRAM_NAME

--- a/spec/differential_check_spec.rb
+++ b/spec/differential_check_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../scripts/differential_check'
+
+RSpec.describe DifferentialCheck::DiffReporter do
+  describe '.unified_diff' do
+    it 'returns nil for byte-identical outputs' do
+      output = "def foo\n  1\nend\n"
+
+      expect(described_class.unified_diff(output, output.dup)).to be_nil
+    end
+
+    it 'reports a deliberately perturbed pair as a unified hunk' do
+      legacy = "def foo\n  1\nend\n"
+      native = "def foo\n  2\nend\n"
+
+      diff = described_class.unified_diff(legacy, native)
+
+      expect(diff).to eq("@@ -2,1 +2,1 @@\n-  1\n+  2")
+    end
+
+    it 'reports a trailing addition' do
+      legacy = "x = 1\n"
+      native = "x = 1\ny = 2\n"
+
+      diff = described_class.unified_diff(legacy, native)
+
+      expect(diff).to eq("@@ -2,0 +2,1 @@\n+y = 2")
+    end
+
+    it 'does not leak common lines when one side purely inserts at the top' do
+      legacy = "b\n"
+      native = "a\nb\n"
+
+      diff = described_class.unified_diff(legacy, native)
+
+      expect(diff).to eq("@@ -1,0 +1,1 @@\n+a")
+    end
+
+    it 'makes a trailing-newline-only difference visible' do
+      legacy = "a\nb"
+      native = "a\nb\n"
+
+      diff = described_class.unified_diff(legacy, native)
+
+      expect(diff).to eq("@@ -2,1 +2,1 @@\n-b\n\\ No newline at end of file\n+b")
+    end
+
+    it 'truncates long diffs to the line limit' do
+      legacy = Array.new(100) { |i| "a#{i}" }.join("\n")
+      native = Array.new(100) { |i| "b#{i}" }.join("\n")
+
+      diff = described_class.unified_diff(legacy, native, limit: 10)
+
+      expect(diff.lines.size).to eq(11)
+      expect(diff).to end_with('more diff lines truncated)')
+    end
+  end
+end
+
+RSpec.describe Rfmt, '.format_native' do
+  it 'matches .format byte-for-byte on a simple program' do
+    source = "def foo( a,b )\n  a+b\nend\n"
+
+    expect(Rfmt.format_native(source)).to eq(Rfmt.format(source))
+  end
+end

--- a/spec/differential_check_spec.rb
+++ b/spec/differential_check_spec.rb
@@ -59,10 +59,10 @@ RSpec.describe DifferentialCheck::DiffReporter do
   end
 end
 
-RSpec.describe Rfmt, '.format_native' do
-  it 'matches .format byte-for-byte on a simple program' do
+RSpec.describe Rfmt, '.format_legacy' do
+  it 'matches the native .format byte-for-byte on a simple program' do
     source = "def foo( a,b )\n  a+b\nend\n"
 
-    expect(Rfmt.format_native(source)).to eq(Rfmt.format(source))
+    expect(Rfmt.format(source)).to eq(Rfmt.format_legacy(source))
   end
 end

--- a/spec/output_validation_spec.rb
+++ b/spec/output_validation_spec.rb
@@ -3,23 +3,17 @@
 require 'spec_helper'
 
 RSpec.describe Rfmt, '.format output validation' do
-  context 'when the formatter produces invalid Ruby' do
-    before do
-      allow(described_class).to receive(:format_code).and_return('def broken(')
-    end
-
-    it 'raises Rfmt::Error mentioning invalid output' do
-      expect do
-        described_class.format('x = 1')
-      end.to raise_error(Rfmt::Error, /invalid output/)
-    end
+  # The invalid-output guard runs inside Rust since the phase-6 switchover,
+  # so it cannot be triggered by stubbing from Ruby anymore. The guard itself
+  # is covered by the Rust unit tests in ext/rfmt/src/validation.rs; here we
+  # pin the public error surface it feeds.
+  it 'exposes Rfmt::ValidationError as an Rfmt::Error' do
+    expect(Rfmt::ValidationError.ancestors).to include(Rfmt::Error)
   end
 
-  context 'without stubbing' do
-    it 'formats valid code normally' do
-      result = described_class.format('x = 1')
+  it 'formats valid code normally' do
+    result = described_class.format('x = 1')
 
-      expect(result).to include('x = 1')
-    end
+    expect(result).to include('x = 1')
   end
 end

--- a/spec/rfmt_spec.rb
+++ b/spec/rfmt_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Rfmt do
 
       expect do
         Rfmt.format(invalid_source)
-      end.to raise_error(Rfmt::Error)
+      end.to raise_error(Rfmt::Error, /\AFailed to parse Ruby code: Parse errors:\n1:/)
     end
 
     it 'formats Rails migration with versioned superclass' do


### PR DESCRIPTION
Phase 6 (switchover) of the ruby-prism migration plan (#110 Phase 3). Note: this PR also carries the two phase 5 commits — PR #118 was merged into its stacked base branch rather than main (GitHub does not retarget when the base branch still exists), so main never received the differential harness. This branch is rebased on main and delivers both.

## What changes for users

`Rfmt.format` now parses natively in Rust. The Ruby Prism parse, the Hash conversion, and the JSON round-trip across FFI are gone from the production path.

**In-process throughput: 4.23 ms/file → 0.34 ms/file (~12x)** on the lib/ corpus (17 files, 5 rounds after warmup, arm64 macOS, `scripts/bench_format.rb`).

Formatted output is byte-identical: the differential harness compares the new path against the retained legacy path over 62 files (`checked: 62, matched: 62, mismatched: 0`), and it keeps running in CI until the legacy path is deleted in phase 7.

## Changes

- `format_code(source)` (arity 1): NativeAdapter parse → policy → config → format → **output re-parsed with ruby-prism inside Rust** (`ext/rfmt/src/validation.rs`, with unit tests). The old arity-2 JSON entry survives as `format_code_legacy` for the harness only.
- `lib/rfmt.rb`: `Rfmt.format` drops PrismBridge and the Ruby-side `validate_output!`; `wrap_native_error` maps the `[Rfmt::ParseError]` / `[Rfmt::ValidationError]` prefixes to the existing public exception classes at the one FFI boundary. `Rfmt.format_legacy` added (temporary). `Rfmt.parse` debug path is native.
- Error surface: parse-error messages are byte-identical to before (verified against the legacy path); `Rfmt::ValidationError` keeps its class and message text, now raised from Rust. The only class change is the no-caller debug API `Rfmt.parse` (`PrismBridge::ParseError` → `Rfmt::Error`).
- Specs: the stub-based guard spec moved to Rust unit tests (the guard is no longer stubbable from Ruby); parse-error message shape is now pinned in `rfmt_spec.rb`.

## Verification

- rspec 167/0 (LSP specs included); corpus check 51/51; differential harness 62/62
- cargo test all suites (validation guard tests included); clippy `--all-targets -D warnings`; fmt clean; rubocop clean
- Real CLI: `--write` formats, `--check` exit codes and parse-error message unchanged
- Reviewer pass (approve): fixed error-prefix leak in `Rfmt.parse`, removed a dead rescue, pinned the message spec

## Follow-ups tracked for later phases

- Phase 7 deletes `format_code_legacy`, `Rfmt.format_legacy`, PrismBridge, the JSON adapter, and the runtime prism gem dependency
- Watch item: nothing currently forces the prism gem (dev-only after phase 7) and ruby-prism crate versions to stay aligned (both 1.9.0 today)
