### PR TITLE
Roadmap Phase 3-8: unify config resolution and cache per-call waste

### DIFF
--- a/ext/rfmt/src/config/mod.rs
+++ b/ext/rfmt/src/config/mod.rs
@@ -1,4 +1,7 @@
 use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::SystemTime;
 
 /// Complete configuration structure matching .rfmt.yml format
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -98,43 +101,86 @@ pub enum TrailingComma {
     Multiline,
 }
 
+/// Search order within each directory: rfmt.yml, rfmt.yaml, .rfmt.yml, .rfmt.yaml
+const CONFIG_FILE_NAMES: [&str; 4] = ["rfmt.yml", "rfmt.yaml", ".rfmt.yml", ".rfmt.yaml"];
+
+/// Discovery result cached per process so repeated format calls (CLI batch,
+/// long-lived LSP) skip the cwd-to-root-to-home filesystem walk.
+struct DiscoveryCache {
+    cwd: PathBuf,
+    /// Discovered file and its mtime; `None` when nothing was found.
+    found: Option<(PathBuf, SystemTime)>,
+    config: Config,
+}
+
+static DISCOVERY_CACHE: Mutex<Option<DiscoveryCache>> = Mutex::new(None);
+
 impl Config {
-    /// Discover configuration file in current directory or parent directories
-    /// Searches in order: rfmt.yml, rfmt.yaml, .rfmt.yml, .rfmt.yaml
-    pub fn discover() -> crate::error::Result<Self> {
-        let config_files = ["rfmt.yml", "rfmt.yaml", ".rfmt.yml", ".rfmt.yaml"];
+    /// Resolve the effective configuration.
+    ///
+    /// Error handling differs by intent: an explicit path was asked for by
+    /// name, so load failures must surface loudly; discovery merely stumbles
+    /// on files, so a broken discovered file logs a warning and falls back
+    /// to defaults (an LSP mid-edit of .rfmt.yml must not break formatting).
+    pub fn resolve(explicit_path: Option<&Path>) -> crate::error::Result<Self> {
+        match explicit_path {
+            Some(path) => Self::load_file(path),
+            None => {
+                let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+                Ok(Self::discover_cached_from(&cwd))
+            }
+        }
+    }
 
-        // Try current directory and parent directories
-        if let Ok(mut current_dir) = std::env::current_dir() {
-            loop {
-                for filename in &config_files {
-                    let config_path = current_dir.join(filename);
-                    if config_path.exists() {
-                        log::info!("Found config file: {:?}", config_path);
-                        return Self::load_file(&config_path);
-                    }
-                }
+    fn discover_cached_from(cwd: &Path) -> Self {
+        let mut guard = DISCOVERY_CACHE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
 
-                // Move to parent directory
-                if !current_dir.pop() {
-                    break;
-                }
+        if let Some(cache) = guard.as_ref() {
+            if cache.cwd == cwd && cache_is_fresh(cwd, cache) {
+                return cache.config.clone();
             }
         }
 
-        // Try home directory
-        if let Some(home_dir) = dirs::home_dir() {
-            for filename in &config_files {
-                let config_path = home_dir.join(filename);
-                if config_path.exists() {
-                    log::debug!("Found config file in home: {:?}", config_path);
-                    return Self::load_file(&config_path);
-                }
+        let (config, found) = Self::discover_from(cwd);
+        *guard = Some(DiscoveryCache {
+            cwd: cwd.to_path_buf(),
+            found,
+            config: config.clone(),
+        });
+        config
+    }
+
+    /// Walk `start` up to the root, then the home directory.
+    fn find_config_file(start: &Path) -> Option<PathBuf> {
+        let mut current_dir = start.to_path_buf();
+        loop {
+            if let Some(path) = first_candidate_in(&current_dir) {
+                return Some(path);
+            }
+            if !current_dir.pop() {
+                break;
             }
         }
 
-        log::info!("No config file found, using defaults");
-        Ok(Config::default())
+        dirs::home_dir().and_then(|home| first_candidate_in(&home))
+    }
+
+    fn discover_from(start: &Path) -> (Self, Option<(PathBuf, SystemTime)>) {
+        let Some(path) = Self::find_config_file(start) else {
+            log::info!("No config file found, using defaults");
+            return (Config::default(), None);
+        };
+
+        // A broken file is still cached with its mtime so fixing it triggers a reload.
+        let config = Self::load_file(&path).unwrap_or_else(|e| {
+            log::warn!("Ignoring config file {:?}: {}", path, e);
+            Config::default()
+        });
+        let mtime = file_mtime(&path).unwrap_or(SystemTime::UNIX_EPOCH);
+        log::info!("Found config file: {:?}", path);
+        (config, Some((path, mtime)))
     }
 
     /// Load configuration from a YAML file
@@ -223,6 +269,35 @@ impl Config {
         }
 
         false
+    }
+}
+
+fn first_candidate_in(dir: &Path) -> Option<PathBuf> {
+    CONFIG_FILE_NAMES
+        .iter()
+        .map(|name| dir.join(name))
+        .find(|path| path.exists())
+}
+
+fn file_mtime(path: &Path) -> Option<SystemTime> {
+    std::fs::metadata(path).and_then(|m| m.modified()).ok()
+}
+
+/// Cheap per-call re-validation replacing the full walk: stat the cwd
+/// candidates (catches a config newly created where formatting runs) and the
+/// discovered file's mtime (catches edits; a vanished file forces a re-walk).
+/// A config appearing only in an intermediate parent directory is not
+/// detected until something else invalidates the cache.
+fn cache_is_fresh(cwd: &Path, cache: &DiscoveryCache) -> bool {
+    let cwd_candidate = first_candidate_in(cwd);
+    match &cache.found {
+        Some((path, mtime)) => {
+            if cwd_candidate.is_some_and(|candidate| candidate != *path) {
+                return false;
+            }
+            file_mtime(path) == Some(*mtime)
+        }
+        None => cwd_candidate.is_none(),
     }
 }
 
@@ -415,6 +490,114 @@ formatting:
         if let Err(RfmtError::ConfigError { message, .. }) = result {
             assert!(message.contains("parse"));
         }
+    }
+
+    // The discovery cache is process-global; serialize the tests that touch it.
+    static CACHE_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn write_indent_config(path: &Path, indent_width: usize) {
+        std::fs::write(
+            path,
+            format!("formatting:\n  indent_width: {indent_width}\n"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_resolve_explicit_missing_path_errors_loudly() {
+        let result = Config::resolve(Some(Path::new("/nonexistent/rfmt.yml")));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_resolve_explicit_broken_file_errors_loudly() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(b"formatting:\n  line_length: not_a_number\n")
+            .unwrap();
+        file.flush().unwrap();
+
+        assert!(Config::resolve(Some(file.path())).is_err());
+    }
+
+    #[test]
+    fn test_discovered_broken_file_falls_back_to_defaults() {
+        let _lock = CACHE_TEST_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("rfmt.yml"),
+            "formatting:\n  indent_width: 99\n",
+        )
+        .unwrap();
+
+        // Unlike an explicit path, discovery swallows load errors.
+        let config = Config::discover_cached_from(dir.path());
+        assert_eq!(config.formatting.indent_width, 2);
+    }
+
+    #[test]
+    fn test_discovery_cache_reloads_on_mtime_change() {
+        let _lock = CACHE_TEST_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rfmt.yml");
+
+        write_indent_config(&path, 4);
+        assert_eq!(
+            Config::discover_cached_from(dir.path())
+                .formatting
+                .indent_width,
+            4
+        );
+
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        write_indent_config(&path, 3);
+        assert_eq!(
+            Config::discover_cached_from(dir.path())
+                .formatting
+                .indent_width,
+            3
+        );
+    }
+
+    #[test]
+    fn test_discovery_cache_missing_file_falls_back_to_walk() {
+        let _lock = CACHE_TEST_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let sub = dir.path().join("sub");
+        std::fs::create_dir(&sub).unwrap();
+        let path = dir.path().join("rfmt.yml");
+
+        write_indent_config(&path, 4);
+        assert_eq!(
+            Config::discover_cached_from(&sub).formatting.indent_width,
+            4
+        );
+
+        std::fs::remove_file(&path).unwrap();
+        assert_eq!(
+            Config::discover_cached_from(&sub).formatting.indent_width,
+            2
+        );
+    }
+
+    #[test]
+    fn test_discovery_nothing_found_cached_then_new_config_in_cwd() {
+        let _lock = CACHE_TEST_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+
+        assert_eq!(
+            Config::discover_cached_from(dir.path())
+                .formatting
+                .indent_width,
+            2
+        );
+
+        write_indent_config(&dir.path().join("rfmt.yml"), 5);
+        assert_eq!(
+            Config::discover_cached_from(dir.path())
+                .formatting
+                .indent_width,
+            5
+        );
     }
 
     #[test]

--- a/ext/rfmt/src/config/mod.rs
+++ b/ext/rfmt/src/config/mod.rs
@@ -115,6 +115,10 @@ struct DiscoveryCache {
 
 static DISCOVERY_CACHE: Mutex<Option<DiscoveryCache>> = Mutex::new(None);
 
+/// Explicit-path loads cached separately, keyed by canonical path + mtime,
+/// so a CLI batch does not re-parse the same YAML once per file.
+static EXPLICIT_CACHE: Mutex<Option<(PathBuf, SystemTime, Config)>> = Mutex::new(None);
+
 impl Config {
     /// Resolve the effective configuration.
     ///
@@ -124,12 +128,36 @@ impl Config {
     /// to defaults (an LSP mid-edit of .rfmt.yml must not break formatting).
     pub fn resolve(explicit_path: Option<&Path>) -> crate::error::Result<Self> {
         match explicit_path {
-            Some(path) => Self::load_file(path),
+            Some(path) => Self::load_explicit_cached(path),
             None => {
                 let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
                 Ok(Self::discover_cached_from(&cwd))
             }
         }
+    }
+
+    fn load_explicit_cached(path: &Path) -> crate::error::Result<Self> {
+        // Canonicalize so a relative path is not confused across cwd changes.
+        let key = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        // mtime read before the load: a racing write can only make the cache
+        // entry look older than the content, forcing a reload, never staleness.
+        let mtime = file_mtime(&key);
+
+        let mut guard = EXPLICIT_CACHE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        if let (Some((cached_path, cached_mtime, config)), Some(mtime)) = (guard.as_ref(), mtime) {
+            if *cached_path == key && *cached_mtime == mtime {
+                return Ok(config.clone());
+            }
+        }
+
+        let config = Self::load_file(path)?;
+        if let Some(mtime) = mtime {
+            *guard = Some((key, mtime, config.clone()));
+        }
+        Ok(config)
     }
 
     fn discover_cached_from(cwd: &Path) -> Self {
@@ -286,7 +314,7 @@ fn file_mtime(path: &Path) -> Option<SystemTime> {
 /// Cheap per-call re-validation replacing the full walk: stat the cwd
 /// candidates (catches a config newly created where formatting runs) and the
 /// discovered file's mtime (catches edits; a vanished file forces a re-walk).
-/// A config appearing only in an intermediate parent directory is not
+/// A config newly created outside cwd (parent directory or home) is not
 /// detected until something else invalidates the cache.
 fn cache_is_fresh(cwd: &Path, cache: &DiscoveryCache) -> bool {
     let cwd_candidate = first_candidate_in(cwd);
@@ -517,6 +545,32 @@ formatting:
         file.flush().unwrap();
 
         assert!(Config::resolve(Some(file.path())).is_err());
+    }
+
+    #[test]
+    fn test_resolve_explicit_path_cached_and_reloaded_on_change() {
+        let _lock = CACHE_TEST_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("custom.yml");
+
+        write_indent_config(&path, 4);
+        assert_eq!(
+            Config::resolve(Some(&path))
+                .unwrap()
+                .formatting
+                .indent_width,
+            4
+        );
+
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        write_indent_config(&path, 3);
+        assert_eq!(
+            Config::resolve(Some(&path))
+                .unwrap()
+                .formatting
+                .indent_width,
+            3
+        );
     }
 
     #[test]

--- a/ext/rfmt/src/error/mod.rs
+++ b/ext/rfmt/src/error/mod.rs
@@ -17,6 +17,9 @@ pub enum RfmtError {
     #[error("{0}")]
     ValidationError(String),
 
+    #[error("{message}")]
+    ConfigError { message: String },
+
     #[error("Format error: {0}")]
     FormatError(String),
 
@@ -25,9 +28,6 @@ pub enum RfmtError {
         feature: String,
         explanation: String,
     },
-
-    #[error("Configuration error: {message}")]
-    ConfigError { message: String },
 }
 
 // Implement From for std::fmt::Error

--- a/ext/rfmt/src/format/formatter.rs
+++ b/ext/rfmt/src/format/formatter.rs
@@ -79,7 +79,7 @@ impl Formatter {
             _ => {
                 // Use the rule registry for specific node types
                 let rule = self.registry.get_rule(&node.node_type);
-                rule.format(node, ctx, &self.registry)
+                rule.format(node, ctx, self.registry)
             }
         }
     }

--- a/ext/rfmt/src/format/formatter.rs
+++ b/ext/rfmt/src/format/formatter.rs
@@ -23,8 +23,8 @@ use super::rule::format_remaining_comments;
 pub struct Formatter {
     /// Configuration for formatting
     config: Config,
-    /// Registry of formatting rules
-    registry: RuleRegistry,
+    /// Registry of formatting rules (shared: rules are stateless)
+    registry: &'static RuleRegistry,
 }
 
 impl Formatter {
@@ -32,13 +32,8 @@ impl Formatter {
     pub fn new(config: Config) -> Self {
         Self {
             config,
-            registry: RuleRegistry::default_registry(),
+            registry: RuleRegistry::shared(),
         }
-    }
-
-    /// Creates a new formatter with a custom registry.
-    pub fn with_registry(config: Config, registry: RuleRegistry) -> Self {
-        Self { config, registry }
     }
 
     /// Formats Ruby source code.
@@ -91,7 +86,7 @@ impl Formatter {
 
     /// Returns a reference to the registry for recursive formatting.
     pub fn registry(&self) -> &RuleRegistry {
-        &self.registry
+        self.registry
     }
 
     /// Formats the program node (root).

--- a/ext/rfmt/src/format/registry.rs
+++ b/ext/rfmt/src/format/registry.rs
@@ -6,6 +6,7 @@
 use crate::ast::NodeType;
 use std::borrow::Cow;
 use std::collections::HashMap;
+use std::sync::OnceLock;
 
 use super::rule::{BoxedRule, FormatRule};
 use super::rules::{
@@ -102,6 +103,13 @@ impl RuleRegistry {
             .get(&key)
             .map(|r| r.as_ref())
             .unwrap_or(self.fallback.as_ref())
+    }
+
+    /// Rules are stateless, so one registry serves every format call;
+    /// building ~23 boxed rules per call was pure waste.
+    pub fn shared() -> &'static Self {
+        static SHARED: OnceLock<RuleRegistry> = OnceLock::new();
+        SHARED.get_or_init(Self::default_registry)
     }
 
     pub fn default_registry() -> Self {

--- a/ext/rfmt/src/lib.rs
+++ b/ext/rfmt/src/lib.rs
@@ -52,6 +52,16 @@ fn format_impl(ruby: &Ruby, source: String, config_path: Option<String>) -> Resu
     Ok(formatted)
 }
 
+/// Serialize the effective configuration so Ruby can display exactly what
+/// the formatter will use (CLI `config` command, --config fail-fast check)
+fn resolved_config_yaml(ruby: &Ruby, config_path: Option<String>) -> Result<String, Error> {
+    let config = Config::resolve(config_path.as_deref().map(std::path::Path::new))
+        .map_err(|e| e.to_magnus_error(ruby))?;
+
+    serde_yaml::to_string(&config)
+        .map_err(|e| Error::new(ruby.exception_standard_error(), e.to_string()))
+}
+
 /// Parse Ruby source code and return the internal AST representation
 /// This is useful for debugging and integration testing
 fn parse_to_json(ruby: &Ruby, source: String) -> Result<String, Error> {
@@ -77,6 +87,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
         function!(format_ruby_code_with_config, 2),
     )?;
     module.define_singleton_method("parse_to_json", function!(parse_to_json, 1))?;
+    module.define_singleton_method("resolved_config_yaml", function!(resolved_config_yaml, 1))?;
     module.define_singleton_method("rust_version", function!(rust_version, 0))?;
 
     Ok(())

--- a/ext/rfmt/src/lib.rs
+++ b/ext/rfmt/src/lib.rs
@@ -25,7 +25,7 @@ fn format_ruby_code(ruby: &Ruby, source: String) -> Result<String, Error> {
     let parser = NativeAdapter::new();
     let ast = parser.parse(&source).map_err(|e| e.to_magnus_error(ruby))?;
 
-    let config = Config::discover().map_err(|e| e.to_magnus_error(ruby))?;
+    let config = Config::resolve(None).map_err(|e| e.to_magnus_error(ruby))?;
     let formatter = Formatter::new(config);
 
     let formatted = formatter

--- a/ext/rfmt/src/lib.rs
+++ b/ext/rfmt/src/lib.rs
@@ -16,6 +16,20 @@ use magnus::{function, prelude::*, Error, Ruby};
 use parser::{NativeAdapter, RubyParser};
 
 fn format_ruby_code(ruby: &Ruby, source: String) -> Result<String, Error> {
+    format_impl(ruby, source, None)
+}
+
+// Separate fixed-arity export instead of a variadic `format_code`: magnus
+// handles fixed signatures natively, so no scan_args parsing to get wrong.
+fn format_ruby_code_with_config(
+    ruby: &Ruby,
+    source: String,
+    config_path: Option<String>,
+) -> Result<String, Error> {
+    format_impl(ruby, source, config_path)
+}
+
+fn format_impl(ruby: &Ruby, source: String, config_path: Option<String>) -> Result<String, Error> {
     let policy = SecurityPolicy::default();
 
     policy
@@ -25,7 +39,8 @@ fn format_ruby_code(ruby: &Ruby, source: String) -> Result<String, Error> {
     let parser = NativeAdapter::new();
     let ast = parser.parse(&source).map_err(|e| e.to_magnus_error(ruby))?;
 
-    let config = Config::resolve(None).map_err(|e| e.to_magnus_error(ruby))?;
+    let config = Config::resolve(config_path.as_deref().map(std::path::Path::new))
+        .map_err(|e| e.to_magnus_error(ruby))?;
     let formatter = Formatter::new(config);
 
     let formatted = formatter
@@ -57,6 +72,10 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     let module = ruby.define_module("Rfmt")?;
 
     module.define_singleton_method("format_code", function!(format_ruby_code, 1))?;
+    module.define_singleton_method(
+        "format_code_with_config",
+        function!(format_ruby_code_with_config, 2),
+    )?;
     module.define_singleton_method("parse_to_json", function!(parse_to_json, 1))?;
     module.define_singleton_method("rust_version", function!(rust_version, 0))?;
 

--- a/lib/rfmt.rb
+++ b/lib/rfmt.rb
@@ -44,7 +44,7 @@ module Rfmt
     elsif message.start_with?(NATIVE_VALIDATION_ERROR_PREFIX)
       ValidationError.new(message.delete_prefix(NATIVE_VALIDATION_ERROR_PREFIX))
     elsif message.start_with?(NATIVE_CONFIG_ERROR_PREFIX)
-      Error.new(message.delete_prefix(NATIVE_CONFIG_ERROR_PREFIX))
+      Error.new("Configuration error: #{message.delete_prefix(NATIVE_CONFIG_ERROR_PREFIX)}")
     else
       Error.new("Unexpected error during formatting: #{error.class}: #{message}")
     end
@@ -59,6 +59,15 @@ module Rfmt
     format(source)
   rescue Errno::ENOENT
     raise Error, "File not found: #{path}"
+  end
+
+  # Effective configuration as the Rust formatter resolves it
+  # @param config_path [String, nil] Explicit config file path; nil discovers
+  # @return [String] YAML dump of the resolved configuration
+  def self.resolved_config(config_path: nil)
+    resolved_config_yaml(config_path&.to_s)
+  rescue StandardError => e
+    raise wrap_native_error(e)
   end
 
   # Get version information
@@ -132,7 +141,8 @@ module Rfmt
       current_dir = Dir.pwd
 
       loop do
-        ['.rfmt.yml', '.rfmt.yaml', 'rfmt.yml', 'rfmt.yaml'].each do |filename|
+        # Same search order as the Rust side (config/mod.rs CONFIG_FILE_NAMES)
+        ['rfmt.yml', 'rfmt.yaml', '.rfmt.yml', '.rfmt.yaml'].each do |filename|
           config_path = File.join(current_dir, filename)
           return config_path if File.exist?(config_path)
         end
@@ -150,7 +160,7 @@ module Rfmt
         nil
       end
       if home_dir
-        ['.rfmt.yml', '.rfmt.yaml', 'rfmt.yml', 'rfmt.yaml'].each do |filename|
+        ['rfmt.yml', 'rfmt.yaml', '.rfmt.yml', '.rfmt.yaml'].each do |filename|
           config_path = File.join(home_dir, filename)
           return config_path if File.exist?(config_path)
         end

--- a/lib/rfmt.rb
+++ b/lib/rfmt.rb
@@ -17,14 +17,22 @@ module Rfmt
   # these two kinds map onto the public exception classes.
   NATIVE_PARSE_ERROR_PREFIX = '[Rfmt::ParseError] '
   NATIVE_VALIDATION_ERROR_PREFIX = '[Rfmt::ValidationError] '
-  private_constant :NATIVE_PARSE_ERROR_PREFIX, :NATIVE_VALIDATION_ERROR_PREFIX
+  NATIVE_CONFIG_ERROR_PREFIX = '[Rfmt::ConfigError] '
+  private_constant :NATIVE_PARSE_ERROR_PREFIX, :NATIVE_VALIDATION_ERROR_PREFIX,
+                   :NATIVE_CONFIG_ERROR_PREFIX
 
   # Format Ruby source code
-  # Parsing and output validation both happen natively in Rust
+  # Parsing, config resolution, and output validation all happen natively in Rust
   # @param source [String] Ruby source code to format
+  # @param config_path [String, nil] Explicit config file path; nil discovers
+  #   rfmt.yml/.rfmt.yml from the current directory upward (cached per process)
   # @return [String] Formatted Ruby code
-  def self.format(source)
-    format_code(source)
+  def self.format(source, config_path: nil)
+    if config_path
+      format_code_with_config(source, config_path.to_s)
+    else
+      format_code(source)
+    end
   rescue StandardError => e
     raise wrap_native_error(e)
   end
@@ -35,6 +43,8 @@ module Rfmt
       Error.new("Failed to parse Ruby code: #{message.delete_prefix(NATIVE_PARSE_ERROR_PREFIX)}")
     elsif message.start_with?(NATIVE_VALIDATION_ERROR_PREFIX)
       ValidationError.new(message.delete_prefix(NATIVE_VALIDATION_ERROR_PREFIX))
+    elsif message.start_with?(NATIVE_CONFIG_ERROR_PREFIX)
+      Error.new(message.delete_prefix(NATIVE_CONFIG_ERROR_PREFIX))
     else
       Error.new("Unexpected error during formatting: #{error.class}: #{message}")
     end

--- a/lib/rfmt/cli.rb
+++ b/lib/rfmt/cli.rb
@@ -45,11 +45,15 @@ module Rfmt
 
   # Command Line Interface for rfmt
   class CLI < Thor
+    def self.exit_on_failure?
+      true
+    end
+
     # Constants
     PROGRESS_THRESHOLD = 20  # Show progress for file counts >= this
     PROGRESS_INTERVAL = 10   # Update progress every N files
 
-    class_option :config, type: :string, desc: 'Path to configuration file'
+    class_option :config, type: :string, desc: 'Path to configuration file (formatting options and file selection)'
     class_option :verbose, type: :boolean, desc: 'Verbose output'
 
     default_command :format
@@ -184,6 +188,8 @@ module Rfmt
 
     def load_config
       if options[:config]
+        raise Thor::Error, "Configuration file not found: #{options[:config]}" unless File.exist?(options[:config])
+
         Configuration.new(file: options[:config])
       else
         Configuration.discover
@@ -256,7 +262,7 @@ module Rfmt
       start_time = Time.now
       source = File.read(file)
 
-      formatted = Rfmt.format(source)
+      formatted = Rfmt.format(source, config_path: options[:config])
       changed = source != formatted
 
       {

--- a/lib/rfmt/cli.rb
+++ b/lib/rfmt/cli.rb
@@ -125,11 +125,11 @@ module Rfmt
       say "Rust extension: #{Rfmt.rust_version}"
     end
 
-    desc 'config', 'Show current configuration'
+    desc 'config', 'Show the effective configuration the formatter will use'
     def config_cmd
-      config = load_config
-      require 'json'
-      say JSON.pretty_generate(config.config)
+      say Rfmt.resolved_config(config_path: options[:config])
+    rescue Rfmt::Error => e
+      raise Thor::Error, e.message
     end
 
     desc 'cache SUBCOMMAND', 'Manage cache'
@@ -188,11 +188,21 @@ module Rfmt
 
     def load_config
       if options[:config]
-        raise Thor::Error, "Configuration file not found: #{options[:config]}" unless File.exist?(options[:config])
-
+        validate_explicit_config!(options[:config])
         Configuration.new(file: options[:config])
       else
         Configuration.discover
+      end
+    end
+
+    # Fail fast once instead of repeating the same load error per file
+    def validate_explicit_config!(path)
+      raise Thor::Error, "Configuration file not found: #{path}" unless File.exist?(path)
+
+      begin
+        Rfmt.resolved_config(config_path: path)
+      rescue Rfmt::Error => e
+        raise Thor::Error, e.message
       end
     end
 

--- a/lib/rfmt/configuration.rb
+++ b/lib/rfmt/configuration.rb
@@ -3,17 +3,13 @@
 require 'yaml'
 
 module Rfmt
-  # Configuration management for rfmt
+  # File selection and cache concerns only: formatter settings (indent_width
+  # etc.) live in the Rust Config, reached via Rfmt.format(config_path:).
   class Configuration
     class ConfigError < StandardError; end
 
     DEFAULT_CONFIG = {
       'version' => '1.0',
-      'formatting' => {
-        'line_length' => 100,
-        'indent_width' => 2,
-        'indent_style' => 'spaces'
-      },
       'include' => ['**/*.rb'],
       'exclude' => ['vendor/**/*', 'tmp/**/*', 'node_modules/**/*']
     }.freeze
@@ -43,11 +39,6 @@ module Rfmt
       (included_files - excluded_files).select { |f| File.file?(f) }
     end
 
-    # Get formatting configuration
-    def formatting_config
-      @config['formatting']
-    end
-
     private
 
     def load_configuration(options)
@@ -64,16 +55,7 @@ module Rfmt
       options.delete('file')
       config = deep_merge(config, options) unless options.empty?
 
-      validate_config!(config)
       config
-    end
-
-    def validate_config!(config)
-      line_length = config.dig('formatting', 'line_length')
-      raise ConfigError, 'line_length must be positive' if line_length && line_length <= 0
-
-      indent_width = config.dig('formatting', 'indent_width')
-      raise ConfigError, 'indent_width must be positive' if indent_width && indent_width <= 0
     end
 
     def deep_merge(hash1, hash2)

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -29,4 +29,56 @@ RSpec.describe Rfmt::CLI do
       end
     end
   end
+
+  describe '--config' do
+    require 'tmpdir'
+
+    it 'applies formatter settings from the explicit config file' do
+      Dir.mktmpdir do |dir|
+        config_path = File.join(dir, 'custom.yml')
+        File.write(config_path, "formatting:\n  indent_width: 4\n")
+        file = File.join(dir, 'test.rb')
+        File.write(file, "class Foo\ndef bar\n42\nend\nend\n")
+
+        described_class.start(['format', '--config', config_path, '--no-cache', file])
+
+        expect(File.read(file).lines).to include("    def bar\n")
+      end
+    end
+
+    it 'fails fast when the config file does not exist' do
+      expect do
+        described_class.start(['format', '--config', 'missing.yml', 'x.rb'])
+      end.to raise_error(SystemExit)
+    end
+
+    it 'fails fast when the config file is invalid' do
+      Dir.mktmpdir do |dir|
+        config_path = File.join(dir, 'broken.yml')
+        File.write(config_path, "formatting:\n  line_length: 20\n")
+        file = File.join(dir, 'test.rb')
+        File.write(file, "x = 1\n")
+
+        expect do
+          described_class.start(['format', '--config', config_path, '--no-cache', file])
+        end.to raise_error(SystemExit)
+      end
+    end
+  end
+
+  describe '#config_cmd' do
+    it 'shows the effective formatter configuration' do
+      Dir.mktmpdir do |dir|
+        config_path = File.join(dir, 'custom.yml')
+        File.write(config_path, "formatting:\n  indent_width: 7\n")
+
+        output = StringIO.new
+        allow($stdout).to receive(:write) { |s| output.write(s) }
+        described_class.start(['config_cmd', '--config', config_path])
+
+        expect(output.string).to include('indent_width: 7')
+        expect(output.string).to include('line_length: 100')
+      end
+    end
+  end
 end

--- a/spec/config_formatting_spec.rb
+++ b/spec/config_formatting_spec.rb
@@ -168,4 +168,58 @@ RSpec.describe 'Config-based formatting' do
       expect(formatted).to include("\t\tputs \"not positive\"")
     end
   end
+
+  describe 'explicit config path' do
+    it 'honors config_path over discovery' do
+      File.write('rfmt.yml', <<~YAML)
+        formatting:
+          indent_width: 2
+      YAML
+      File.write('custom.yml', <<~YAML)
+        formatting:
+          indent_width: 4
+      YAML
+
+      formatted = Rfmt.format(source_code, config_path: 'custom.yml')
+
+      expect(formatted.lines).to include("    def initialize(name)\n")
+    end
+
+    it 'raises loudly when the explicit path does not exist' do
+      expect do
+        Rfmt.format(source_code, config_path: 'missing.yml')
+      end.to raise_error(Rfmt::Error, /Failed to read config file/)
+    end
+
+    it 'raises loudly when the explicit file is invalid' do
+      File.write('broken.yml', <<~YAML)
+        formatting:
+          line_length: 20
+      YAML
+
+      # Discovery swallows broken files into defaults; an explicit path must not.
+      expect do
+        Rfmt.format(source_code, config_path: 'broken.yml')
+      end.to raise_error(Rfmt::Error, /line_length/)
+    end
+  end
+
+  describe 'discovery cache invalidation' do
+    it 'picks up edits to the discovered config between in-process calls' do
+      File.write('.rfmt.yml', <<~YAML)
+        formatting:
+          indent_width: 4
+      YAML
+      expect(Rfmt.format(source_code).lines).to include("    def initialize(name)\n")
+
+      File.write('.rfmt.yml', <<~YAML)
+        formatting:
+          indent_width: 3
+      YAML
+      # Force a distinct mtime so the test does not depend on filesystem timestamp resolution
+      File.utime(Time.now, Time.now + 2, '.rfmt.yml')
+
+      expect(Rfmt.format(source_code).lines).to include("   def initialize(name)\n")
+    end
+  end
 end


### PR DESCRIPTION
Phase 8 of the ruby-prism migration plan (#110 Phase 3): one config system, and the per-call waste that the fork model used to hide is gone.

## What changes for users

**`--config PATH` actually works now.** It was silently ignored by the formatter: the Ruby side only used it for file selection while Rust independently re-discovered config on every call. Now:

- `rfmt --config custom.yml --write file.rb` applies the file's formatting settings (verified end-to-end with a distinctive `indent_width`)
- an explicitly passed config that is missing or invalid **fails loudly with exit 1, once** — before, a Thor bug (`exit_on_failure?` undefined) meant even error paths exited 0
- `rfmt config` now prints the effective settings the Rust formatter actually resolved (via a new `resolved_config_yaml` FFI), instead of a Ruby-side approximation
- discovery (`.rfmt.yml` etc.) is unchanged for well-formed files; a *broken discovered* file now warns and falls back to defaults instead of failing every format (deliberate: an LSP mid-edit of `.rfmt.yml` should not make formatting impossible). Explicit-path errors stay loud — the asymmetry is documented and tested

**Long-lived processes pick up config edits**: discovery results are cached keyed by cwd + found-file mtime; editing `.rfmt.yml` between two in-process formats changes the output (tested). Known limit (in code): a config newly created in a *parent* directory is picked up on the next cache invalidation, not instantly.

## Performance

`Config::discover()` was a cwd→root→home filesystem walk on every `Rfmt.format` call, and `Formatter::new` rebuilt the 23-rule registry each time. With the discovery cache (walk → one stat batch), an explicit-path cache, and a `OnceLock` registry:

| | ms/file (in-process, lib corpus) |
|---|---|
| before this PR | 0.357 |
| after | **0.190** |

Cumulative since the migration started: 4.28 → 0.19 ms/file (~22x).

## Design notes

- FFI: two fixed-arity functions (`format_code`/1, `format_code_with_config`/2) instead of magnus variadic parsing; config crosses the boundary as a PATH so YAML parsing stays in one place
- `Rfmt.format(source, config_path: nil)` keeps the positional call compatible
- `Configuration` (Ruby) shrinks to file-selection/cache concerns; the three discovery implementations now share one search order (full dedup left out of scope, noted in the plan)

## Verification

- rspec 166/0 (new: explicit-path honored / missing / invalid, mtime invalidation, CLI e2e); corpus check 46/46
- cargo test 145 (new cache tests: mtime reload, file-vanished re-walk, not-found caching with cwd-creation detection, explicit-path error semantics); clippy/fmt/rubocop clean
- Real CLI transcript in the PR discussion above; re-verified independently (indent honored, exit 1 on missing config)
- Benchmark: three runs, 0.190–0.207 ms/file
