### PR TITLE
Fix data section loss, chain indent idempotency, and else comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Parsing now happens natively in Rust. The Ruby-side Prism parse and JSON handoff
 - Output-validation guard: formatted output is re-parsed and rejected if it fails to parse
 - Corpus check (`scripts/corpus_check.rb`): reformats every Ruby file in the repository and verifies AST equivalence with the prism gem; runs in CI alongside the parity fixtures
 
+### Fixed
+
+- The `__END__` data section is no longer dropped from formatted output; everything from `__END__` to EOF is preserved byte-for-byte
+- Method chain continuation indentation is now computed from the statement's output position instead of its input column, so misindented input converges in a single pass; heredoc bodies inside a reformatted chain keep their content byte-identical
+- A trailing comment on an `else` line stays on that line instead of moving below it
+
 ### Removed
 
 - prism gem runtime dependency; it remains a development-only dependency for the corpus check and parity fixtures

--- a/ext/rfmt/src/format/formatter.rs
+++ b/ext/rfmt/src/format/formatter.rs
@@ -66,7 +66,23 @@ impl Formatter {
 
         // 5. Print to string
         let mut printer = Printer::new(&self.config);
-        let result = printer.print(&final_doc);
+        let mut result = printer.print(&final_doc);
+
+        // 6. Re-append the `__END__` data section, which the AST excludes.
+        // Appended after printing (and its trailing-whitespace strip) so the
+        // data content survives byte-for-byte.
+        if let Some(data) = ast
+            .metadata
+            .get("data_start_offset")
+            .and_then(|offset| offset.parse::<usize>().ok())
+            .and_then(|offset| source.get(offset..))
+        {
+            if !result.is_empty() {
+                result.truncate(result.trim_end_matches('\n').len());
+                result.push('\n');
+            }
+            result.push_str(data);
+        }
 
         Ok(result)
     }

--- a/ext/rfmt/src/format/rule.rs
+++ b/ext/rfmt/src/format/rule.rs
@@ -4,7 +4,9 @@
 //! along with shared helper functions for common formatting patterns.
 
 use crate::ast::{CommentType, Node};
-use crate::doc::{concat, hardline, leading_comment, literalline, text, trailing_comment, Doc};
+use crate::doc::{
+    concat, hardline, indent, leading_comment, literalline, text, trailing_comment, Doc,
+};
 use crate::error::Result;
 
 use super::context::FormatContext;
@@ -437,139 +439,165 @@ pub fn format_statements(
 
 /// Returns the number of leading space/tab characters on the line containing `offset`.
 ///
-/// The source text extracted by `FormatContext::extract_source` starts at the node's
-/// offset and does not include the whitespace that precedes the first line in the
-/// original source. `Doc::Text` is printed verbatim without re-indenting embedded
-/// newlines, so any reformatting that emits a multi-line string must include the
-/// original leading indent itself.
-pub fn line_leading_indent(source: &str, offset: usize) -> usize {
-    let offset = offset.min(source.len());
-    let line_start = source[..offset].rfind('\n').map(|p| p + 1).unwrap_or(0);
-    source.as_bytes()[line_start..offset]
-        .iter()
-        .take_while(|&&b| b == b' ' || b == b'\t')
-        .count()
-}
-
-/// Reformats multiline method chain text with indented style.
-///
-/// Converts aligned method chains to indented style:
+/// Reformats a multiline method chain into a Doc that lets the printer own
+/// line anchoring, so the output is independent of the statement's column
+/// in the INPUT source (misindented input formats the same as clean input):
 /// - First line is kept as-is (trimmed at end)
-/// - Subsequent lines starting with `.` or `&.` are re-indented to
-///   `base_indent + indent_width` spaces
+/// - Chain continuation lines (`.` / `&.`) become `hardline` + trimmed body
+///   inside `indent(...)`, rendering one indent level below wherever the
+///   statement lands in the output
+/// - Other lines at or beyond the original chain indent (multi-line
+///   arguments of a chain call) keep their offset RELATIVE to the chain
+///   lines, baked as leading spaces on top of the hardline anchor
+/// - Heredoc body lines and shallower lines are emitted verbatim after a
+///   `literalline` — for plain/dash heredocs the leading whitespace is
+///   string content, so shifting it would change program semantics
 ///
-/// `base_indent` is the column at which the first line starts in the original source
-/// (obtain via `line_leading_indent`). Because `Doc::Text` is printed verbatim without
-/// re-indenting embedded newlines, this indent must be included in the returned string.
-///
-/// Returns `Cow::Borrowed` when no transformation is needed to avoid allocation.
-///
-/// # Example
-/// ```text
-/// Input (base_indent=4, indent_width=2):
-///   "foo.bar\n                  .baz"
-/// Output:
-///   "foo.bar\n      .baz"
-/// ```
-pub fn reformat_chain_lines(
-    source_text: &str,
-    base_indent: usize,
-    indent_width: usize,
-) -> std::borrow::Cow<'_, str> {
-    use std::borrow::Cow;
-
+/// Returns `None` when no transformation applies; callers fall back to the
+/// verbatim source text.
+pub fn reformat_chain_doc(source_text: &str) -> Option<Doc> {
     let lines: Vec<&str> = source_text.lines().collect();
     if lines.len() <= 1 {
-        return Cow::Borrowed(source_text);
+        return None;
     }
+
+    let heredoc_body = heredoc_body_lines(&lines);
 
     // Skip reformatting when the first line opens a new scope (a `{` brace
     // lambda, a `do` block, or a `do |params|` block). The `.method` lines
     // that follow are chain continuations *inside the block body*, not of
-    // the outer call — re-indenting them relative to the outer
-    // `base_indent` collapses the nested chain one level to the left and
-    // breaks the visual structure of the block body.
+    // the outer call — re-indenting them relative to the outer statement
+    // collapses the nested chain one level to the left and breaks the
+    // visual structure of the block body.
     //
     // This deliberately keeps the reformat conservative: for a top-level
     // `User.active.where(...)` chain, line 1 ends with an identifier so
     // we still rewrite aligned → indented as PR #100 intended.
     let first_line = lines[0].trim_end();
     if first_line.ends_with('{') || first_line.ends_with(" do") || first_line.ends_with('|') {
-        return Cow::Borrowed(source_text);
+        return None;
     }
 
-    // Check if there are actual chain continuation lines (. or &.)
-    let has_chain = lines[1..].iter().any(|l| {
-        let t = l.trim_start();
-        t.starts_with('.') || t.starts_with("&.")
-    });
-
-    if !has_chain {
-        return Cow::Borrowed(source_text);
-    }
-
-    // Determine how much the chain is moving left. Before this pass, every
-    // `.method` line sat at some original "chain indent" (most commonly
-    // aligned under the first receiver's dot). We rewrite those lines to
-    // `base_indent + indent_width` — but that also means any multi-line
-    // *arguments* that lived inside a chain call like `.select( … )` used
-    // to be deeper than the original chain indent, and will now look
-    // orphaned off to the right if we leave them alone:
-    //
-    //     @users = User.left_joins(...)
-    //                 .select(           <- was col 17, becomes col 6
-    //                   'users.*, ' \   <- still at col 19 — orphaned
-    //                 )
-    //                 .having(...)
-    //
-    // Compute the delta between the original chain indent and the new
-    // one, and shift every non-chain continuation line that lives at
-    // (or below) the original chain indent by the same amount. Lines
-    // shallower than the original chain indent (e.g. a heredoc body
-    // whose squiggly indent is measured from the terminator) are left
-    // alone, so we don't accidentally eat through them.
-    let new_chain_indent = base_indent + indent_width;
-    let chain_indent_str = " ".repeat(new_chain_indent);
-
-    let original_chain_indent = lines[1..].iter().find_map(|l| {
+    // The original chain indent anchors the relative offsets of multi-line
+    // argument lines; without any chain continuation line there is nothing
+    // to reformat.
+    let chain_indent = lines.iter().enumerate().skip(1).find_map(|(i, l)| {
+        if heredoc_body[i] {
+            return None;
+        }
         let t = l.trim_start();
         if t.starts_with('.') || t.starts_with("&.") {
             Some(l.len() - t.len())
         } else {
             None
         }
-    });
+    })?;
 
-    let arg_shift = original_chain_indent
-        .map(|orig| orig.saturating_sub(new_chain_indent))
-        .unwrap_or(0);
-
-    let mut result = String::with_capacity(source_text.len());
-    result.push_str(lines[0].trim_end());
-
-    for line in &lines[1..] {
-        result.push('\n');
-        let trimmed = line.trim();
-        if trimmed.starts_with('.') || trimmed.starts_with("&.") {
-            result.push_str(&chain_indent_str);
-            result.push_str(trimmed);
-        } else if arg_shift > 0 && !trimmed.is_empty() {
-            let indent = line.len() - line.trim_start().len();
-            let chain_base = original_chain_indent.unwrap_or(0);
-            if indent >= chain_base {
-                let new_indent = indent - arg_shift;
-                result.push_str(&" ".repeat(new_indent));
-                result.push_str(line.trim_start());
-            } else {
-                result.push_str(line);
-            }
+    let mut rest: Vec<Doc> = Vec::with_capacity((lines.len() - 1) * 2);
+    for (i, line) in lines.iter().enumerate().skip(1) {
+        let body = line.trim_start();
+        let indent_cols = line.len() - body.len();
+        if heredoc_body[i] {
+            rest.push(literalline());
+            rest.push(text((*line).to_string()));
+        } else if body.starts_with('.') || body.starts_with("&.") {
+            rest.push(hardline());
+            rest.push(text(body.trim_end().to_string()));
+        } else if !body.is_empty() && indent_cols >= chain_indent {
+            // Multi-line arguments inside a chain call like `.select( … )`
+            // move together with the chain lines they belong to.
+            rest.push(hardline());
+            rest.push(text(format!(
+                "{}{}",
+                " ".repeat(indent_cols - chain_indent),
+                body.trim_end()
+            )));
         } else {
-            // Non-chain continuation (e.g., heredoc content): preserve as-is
-            result.push_str(line);
+            rest.push(literalline());
+            rest.push(text((*line).to_string()));
         }
     }
 
-    Cow::Owned(result)
+    Some(concat(vec![
+        text(first_line.to_string()),
+        indent(concat(rest)),
+    ]))
+}
+
+struct HeredocOpener {
+    terminator: String,
+    /// `<<-` / `<<~` allow the terminator line to be indented.
+    indented_terminator: bool,
+}
+
+/// Lexically marks lines that are heredoc bodies (including terminator
+/// lines). Openers on one line stack in source order, and each body runs
+/// until its terminator. When a terminator is ambiguous (e.g. a stray `\r`)
+/// this errs toward marking more lines as body, which only makes the
+/// reformat emit them verbatim — the semantics-safe direction.
+fn heredoc_body_lines(lines: &[&str]) -> Vec<bool> {
+    let mut body = vec![false; lines.len()];
+    let mut pending: std::collections::VecDeque<HeredocOpener> = std::collections::VecDeque::new();
+    for (i, line) in lines.iter().enumerate() {
+        if let Some(front) = pending.front() {
+            body[i] = true;
+            let candidate = if front.indented_terminator {
+                line.trim_start()
+            } else {
+                line
+            };
+            if candidate.trim_end_matches('\r') == front.terminator {
+                pending.pop_front();
+            }
+            continue;
+        }
+        scan_heredoc_openers(line, &mut pending);
+    }
+    body
+}
+
+/// Finds `<<ID` / `<<-ID` / `<<~ID` openers (identifier optionally wrapped
+/// in `"` / `'` / `` ` ``) in a code line. Purely lexical: openers inside
+/// string literals or comments are false positives, tolerated because they
+/// only cause verbatim emission.
+fn scan_heredoc_openers(line: &str, pending: &mut std::collections::VecDeque<HeredocOpener>) {
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    while i + 2 < bytes.len() {
+        if bytes[i] != b'<' || bytes[i + 1] != b'<' {
+            i += 1;
+            continue;
+        }
+        let mut j = i + 2;
+        let indented = matches!(bytes.get(j), Some(b'-') | Some(b'~'));
+        if indented {
+            j += 1;
+        }
+        let quote = match bytes.get(j) {
+            Some(&q @ (b'"' | b'\'' | b'`')) => {
+                j += 1;
+                Some(q)
+            }
+            _ => None,
+        };
+        let start = j;
+        while j < bytes.len() && (bytes[j].is_ascii_alphanumeric() || bytes[j] == b'_') {
+            j += 1;
+        }
+        let valid = j > start
+            && (bytes[start].is_ascii_alphabetic() || bytes[start] == b'_')
+            && quote.is_none_or(|q| bytes.get(j) == Some(&q));
+        if !valid {
+            // Skip both `<` so `a <<< b` or `x <<= y` cannot rescan.
+            i += 2;
+            continue;
+        }
+        pending.push_back(HeredocOpener {
+            terminator: line[start..j].to_string(),
+            indented_terminator: indented,
+        });
+        i = j + usize::from(quote.is_some());
+    }
 }
 
 /// Returns true when the given 1-based `line` in `source` contains only
@@ -767,54 +795,72 @@ mod tests {
         assert!(!matches!(doc, Doc::Empty));
     }
 
-    #[test]
-    fn test_reformat_chain_lines_single_line() {
-        let input = "foo.bar.baz";
-        let result = reformat_chain_lines(input, 0, 2);
-        assert_eq!(result, "foo.bar.baz");
+    fn print(doc: Doc) -> String {
+        let config = Config::default();
+        let mut printer = crate::doc::Printer::new(&config);
+        printer.print(&doc)
     }
 
     #[test]
-    fn test_reformat_chain_lines_multiline_chain() {
+    fn test_reformat_chain_doc_single_line() {
+        assert!(reformat_chain_doc("foo.bar.baz").is_none());
+    }
+
+    #[test]
+    fn test_reformat_chain_doc_multiline_chain() {
         let input = "foo.bar\n                  .baz\n                  .qux";
-        let result = reformat_chain_lines(input, 0, 2);
-        assert_eq!(result, "foo.bar\n  .baz\n  .qux");
+        let doc = reformat_chain_doc(input).unwrap();
+        assert_eq!(print(doc), "foo.bar\n  .baz\n  .qux\n");
     }
 
     #[test]
-    fn test_reformat_chain_lines_safe_navigation() {
+    fn test_reformat_chain_doc_safe_navigation() {
         let input = "foo&.bar\n                  &.baz";
-        let result = reformat_chain_lines(input, 0, 2);
-        assert_eq!(result, "foo&.bar\n  &.baz");
+        let doc = reformat_chain_doc(input).unwrap();
+        assert_eq!(print(doc), "foo&.bar\n  &.baz\n");
     }
 
     #[test]
-    fn test_reformat_chain_lines_no_chain() {
-        let input = "foo(\n  arg1,\n  arg2\n)";
-        let result = reformat_chain_lines(input, 0, 2);
-        assert_eq!(result, input);
+    fn test_reformat_chain_doc_no_chain() {
+        assert!(reformat_chain_doc("foo(\n  arg1,\n  arg2\n)").is_none());
     }
 
     #[test]
-    fn test_reformat_chain_lines_preserves_base_indent() {
-        // Simulates a chain inside a 4-space-indented method body:
-        // the caller must include base_indent so the printed continuation
-        // lines up with `base_indent + indent_width` columns.
-        let input = "foo.bar\n                  .baz\n                  .qux";
-        let result = reformat_chain_lines(input, 4, 2);
-        assert_eq!(result, "foo.bar\n      .baz\n      .qux");
+    fn test_reformat_chain_doc_independent_of_input_column() {
+        // The doc carries no absolute indent: differently misindented
+        // inputs of the same chain print identically.
+        let aligned = "foo.bar\n                  .baz";
+        let flush = "foo.bar\n.baz";
+        let a = print(reformat_chain_doc(aligned).unwrap());
+        let b = print(reformat_chain_doc(flush).unwrap());
+        assert_eq!(a, b);
+        assert_eq!(a, "foo.bar\n  .baz\n");
     }
 
     #[test]
-    fn test_line_leading_indent_counts_spaces_and_tabs() {
-        let source = "def foo\n    bar\n\tbaz\nqux\n";
-        let bar = source.find("bar").unwrap();
-        let baz = source.find("baz").unwrap();
-        let qux = source.find("qux").unwrap();
-        assert_eq!(line_leading_indent(source, bar), 4);
-        assert_eq!(line_leading_indent(source, baz), 1);
-        assert_eq!(line_leading_indent(source, qux), 0);
-        // Out-of-range offset is clamped.
-        assert_eq!(line_leading_indent(source, usize::MAX), 0);
+    fn test_reformat_chain_doc_argument_lines_stay_relative_to_chain() {
+        let input = "u = User.all\n      .select(\n        :id,\n      )\n      .to_a";
+        let doc = reformat_chain_doc(input).unwrap();
+        assert_eq!(print(doc), "u = User.all\n  .select(\n    :id,\n  )\n  .to_a\n");
+    }
+
+    #[test]
+    fn test_reformat_chain_doc_keeps_plain_heredoc_body_verbatim() {
+        let input = "result = base\n      .where(<<SQL)\n        a = 1\nSQL\n      .order(:id)";
+        let doc = reformat_chain_doc(input).unwrap();
+        assert_eq!(
+            print(doc),
+            "result = base\n  .where(<<SQL)\n        a = 1\nSQL\n  .order(:id)\n"
+        );
+    }
+
+    #[test]
+    fn test_reformat_chain_doc_stacked_heredoc_openers() {
+        let input = "r = base\n      .merge(<<-A, <<~\"B\")\n        one\n      A\n        two\n      B\n      .to_a";
+        let doc = reformat_chain_doc(input).unwrap();
+        assert_eq!(
+            print(doc),
+            "r = base\n  .merge(<<-A, <<~\"B\")\n        one\n      A\n        two\n      B\n  .to_a\n"
+        );
     }
 }

--- a/ext/rfmt/src/format/rule.rs
+++ b/ext/rfmt/src/format/rule.rs
@@ -3,6 +3,8 @@
 //! This module defines the core FormatRule trait that all formatting rules implement,
 //! along with shared helper functions for common formatting patterns.
 
+use std::collections::VecDeque;
+
 use crate::ast::{CommentType, Node};
 use crate::doc::{
     concat, hardline, indent, leading_comment, literalline, text, trailing_comment, Doc,
@@ -461,8 +463,6 @@ pub fn reformat_chain_doc(source_text: &str) -> Option<Doc> {
         return None;
     }
 
-    let heredoc_body = heredoc_body_lines(&lines);
-
     // Skip reformatting when the first line opens a new scope (a `{` brace
     // lambda, a `do` block, or a `do |params|` block). The `.method` lines
     // that follow are chain continuations *inside the block body*, not of
@@ -478,6 +478,18 @@ pub fn reformat_chain_doc(source_text: &str) -> Option<Doc> {
         return None;
     }
 
+    // Cheap pre-check before the heredoc scan; a false positive from a
+    // `.`-leading heredoc body line only costs the scan below, whose masked
+    // chain_indent search then bails.
+    if !lines[1..]
+        .iter()
+        .any(|l| is_chain_continuation(l.trim_start()))
+    {
+        return None;
+    }
+
+    let heredoc_body = heredoc_body_lines(&lines);
+
     // The original chain indent anchors the relative offsets of multi-line
     // argument lines; without any chain continuation line there is nothing
     // to reformat.
@@ -486,7 +498,7 @@ pub fn reformat_chain_doc(source_text: &str) -> Option<Doc> {
             return None;
         }
         let t = l.trim_start();
-        if t.starts_with('.') || t.starts_with("&.") {
+        if is_chain_continuation(t) {
             Some(l.len() - t.len())
         } else {
             None
@@ -500,7 +512,7 @@ pub fn reformat_chain_doc(source_text: &str) -> Option<Doc> {
         if heredoc_body[i] {
             rest.push(literalline());
             rest.push(text((*line).to_string()));
-        } else if body.starts_with('.') || body.starts_with("&.") {
+        } else if is_chain_continuation(body) {
             rest.push(hardline());
             rest.push(text(body.trim_end().to_string()));
         } else if !body.is_empty() && indent_cols >= chain_indent {
@@ -524,6 +536,17 @@ pub fn reformat_chain_doc(source_text: &str) -> Option<Doc> {
     ]))
 }
 
+/// `reformat_chain_doc` with the shared fallback: verbatim source text,
+/// stripped of one trailing newline.
+pub fn chain_doc_or_verbatim(source_text: &str) -> Doc {
+    reformat_chain_doc(source_text)
+        .unwrap_or_else(|| text(strip_one_trailing_newline(source_text).to_string()))
+}
+
+fn is_chain_continuation(trimmed: &str) -> bool {
+    trimmed.starts_with('.') || trimmed.starts_with("&.")
+}
+
 struct HeredocOpener {
     terminator: String,
     /// `<<-` / `<<~` allow the terminator line to be indented.
@@ -537,7 +560,7 @@ struct HeredocOpener {
 /// reformat emit them verbatim — the semantics-safe direction.
 fn heredoc_body_lines(lines: &[&str]) -> Vec<bool> {
     let mut body = vec![false; lines.len()];
-    let mut pending: std::collections::VecDeque<HeredocOpener> = std::collections::VecDeque::new();
+    let mut pending: VecDeque<HeredocOpener> = VecDeque::new();
     for (i, line) in lines.iter().enumerate() {
         if let Some(front) = pending.front() {
             body[i] = true;
@@ -560,7 +583,7 @@ fn heredoc_body_lines(lines: &[&str]) -> Vec<bool> {
 /// in `"` / `'` / `` ` ``) in a code line. Purely lexical: openers inside
 /// string literals or comments are false positives, tolerated because they
 /// only cause verbatim emission.
-fn scan_heredoc_openers(line: &str, pending: &mut std::collections::VecDeque<HeredocOpener>) {
+fn scan_heredoc_openers(line: &str, pending: &mut VecDeque<HeredocOpener>) {
     let bytes = line.as_bytes();
     let mut i = 0;
     while i + 2 < bytes.len() {
@@ -841,7 +864,10 @@ mod tests {
     fn test_reformat_chain_doc_argument_lines_stay_relative_to_chain() {
         let input = "u = User.all\n      .select(\n        :id,\n      )\n      .to_a";
         let doc = reformat_chain_doc(input).unwrap();
-        assert_eq!(print(doc), "u = User.all\n  .select(\n    :id,\n  )\n  .to_a\n");
+        assert_eq!(
+            print(doc),
+            "u = User.all\n  .select(\n    :id,\n  )\n  .to_a\n"
+        );
     }
 
     #[test]

--- a/ext/rfmt/src/format/rules/call.rs
+++ b/ext/rfmt/src/format/rules/call.rs
@@ -5,8 +5,6 @@
 //! - Calls with blocks: `foo.bar do ... end` or `foo.bar { ... }`
 //! - Method chains: `foo.bar.baz`
 
-use std::borrow::Cow;
-
 use crate::ast::{Node, NodeType};
 use crate::doc::{align, concat, hardline, indent, text, Doc};
 use crate::error::Result;
@@ -14,8 +12,8 @@ use crate::format::context::FormatContext;
 use crate::format::registry::RuleRegistry;
 use crate::format::rule::{
     format_child, format_comments_before_end, format_leading_comments, format_statements,
-    format_trailing_comment, line_leading_indent, mark_comments_in_range_emitted,
-    reformat_chain_lines, strip_one_trailing_newline, FormatRule,
+    format_trailing_comment, mark_comments_in_range_emitted, reformat_chain_doc,
+    strip_one_trailing_newline, FormatRule,
 };
 
 /// Rule for formatting method calls.
@@ -114,14 +112,10 @@ fn format_call(node: &Node, ctx: &mut FormatContext, registry: &RuleRegistry) ->
         // the full `trim_end` here would instead eat a blank separator line
         // that legitimately belongs between statements.
         if let Some(source_text) = ctx.extract_source(node) {
-            let base_indent = line_leading_indent(ctx.source(), node.location.start_offset);
-            let reformatted = reformat_chain_lines(
-                source_text,
-                base_indent,
-                ctx.config().formatting.indent_width,
-            );
-            let trimmed = strip_one_trailing_newline(&reformatted);
-            docs.push(text(trimmed.to_string()));
+            match reformat_chain_doc(source_text) {
+                Some(chain_doc) => docs.push(chain_doc),
+                None => docs.push(text(strip_one_trailing_newline(source_text).to_string())),
+            }
         }
 
         // Mark comments in this range as emitted (they're in source extraction)
@@ -148,15 +142,16 @@ fn format_call(node: &Node, ctx: &mut FormatContext, registry: &RuleRegistry) ->
         .source()
         .get(node.location.start_offset..call_end_offset)
     {
-        let base_indent = line_leading_indent(ctx.source(), node.location.start_offset);
-        let reformatted = reformat_chain_lines(
-            call_text.trim_end(),
-            base_indent,
-            ctx.config().formatting.indent_width,
-        );
-        let changed = matches!(reformatted, Cow::Owned(_));
-        docs.push(text(reformatted));
-        changed
+        match reformat_chain_doc(call_text.trim_end()) {
+            Some(chain_doc) => {
+                docs.push(chain_doc);
+                true
+            }
+            None => {
+                docs.push(text(call_text.trim_end().to_string()));
+                false
+            }
+        }
     } else {
         false
     };

--- a/ext/rfmt/src/format/rules/call.rs
+++ b/ext/rfmt/src/format/rules/call.rs
@@ -11,9 +11,9 @@ use crate::error::Result;
 use crate::format::context::FormatContext;
 use crate::format::registry::RuleRegistry;
 use crate::format::rule::{
-    format_child, format_comments_before_end, format_leading_comments, format_statements,
-    format_trailing_comment, mark_comments_in_range_emitted, reformat_chain_doc,
-    strip_one_trailing_newline, FormatRule,
+    chain_doc_or_verbatim, format_child, format_comments_before_end, format_leading_comments,
+    format_statements, format_trailing_comment, mark_comments_in_range_emitted, reformat_chain_doc,
+    FormatRule,
 };
 
 /// Rule for formatting method calls.
@@ -112,10 +112,7 @@ fn format_call(node: &Node, ctx: &mut FormatContext, registry: &RuleRegistry) ->
         // the full `trim_end` here would instead eat a blank separator line
         // that legitimately belongs between statements.
         if let Some(source_text) = ctx.extract_source(node) {
-            match reformat_chain_doc(source_text) {
-                Some(chain_doc) => docs.push(chain_doc),
-                None => docs.push(text(strip_one_trailing_newline(source_text).to_string())),
-            }
+            docs.push(chain_doc_or_verbatim(source_text));
         }
 
         // Mark comments in this range as emitted (they're in source extraction)

--- a/ext/rfmt/src/format/rules/fallback.rs
+++ b/ext/rfmt/src/format/rules/fallback.rs
@@ -10,8 +10,8 @@ use crate::error::Result;
 use crate::format::context::FormatContext;
 use crate::format::registry::RuleRegistry;
 use crate::format::rule::{
-    format_leading_comments, format_trailing_comment, line_leading_indent,
-    mark_comments_in_range_emitted, reformat_chain_lines, strip_one_trailing_newline, FormatRule,
+    format_leading_comments, format_trailing_comment, mark_comments_in_range_emitted,
+    reformat_chain_doc, strip_one_trailing_newline, FormatRule,
 };
 
 /// Fallback rule that extracts source text directly.
@@ -47,14 +47,10 @@ impl FormatRule for FallbackRule {
         // could swallow an intentional blank line captured by the node's
         // extent).
         if let Some(source_text) = ctx.extract_source(node) {
-            let base_indent = line_leading_indent(ctx.source(), node.location.start_offset);
-            let reformatted = reformat_chain_lines(
-                source_text,
-                base_indent,
-                ctx.config().formatting.indent_width,
-            );
-            let trimmed = strip_one_trailing_newline(&reformatted);
-            docs.push(text(trimmed.to_string()));
+            match reformat_chain_doc(source_text) {
+                Some(chain_doc) => docs.push(chain_doc),
+                None => docs.push(text(strip_one_trailing_newline(source_text).to_string())),
+            }
 
             // Mark any comments within this node's range as emitted
             // (they are included in the source extraction)

--- a/ext/rfmt/src/format/rules/fallback.rs
+++ b/ext/rfmt/src/format/rules/fallback.rs
@@ -5,13 +5,13 @@
 //! net for node types that haven't been implemented yet.
 
 use crate::ast::Node;
-use crate::doc::{concat, text, Doc};
+use crate::doc::{concat, Doc};
 use crate::error::Result;
 use crate::format::context::FormatContext;
 use crate::format::registry::RuleRegistry;
 use crate::format::rule::{
-    format_leading_comments, format_trailing_comment, mark_comments_in_range_emitted,
-    reformat_chain_doc, strip_one_trailing_newline, FormatRule,
+    chain_doc_or_verbatim, format_leading_comments, format_trailing_comment,
+    mark_comments_in_range_emitted, FormatRule,
 };
 
 /// Fallback rule that extracts source text directly.
@@ -47,10 +47,7 @@ impl FormatRule for FallbackRule {
         // could swallow an intentional blank line captured by the node's
         // extent).
         if let Some(source_text) = ctx.extract_source(node) {
-            match reformat_chain_doc(source_text) {
-                Some(chain_doc) => docs.push(chain_doc),
-                None => docs.push(text(strip_one_trailing_newline(source_text).to_string())),
-            }
+            docs.push(chain_doc_or_verbatim(source_text));
 
             // Mark any comments within this node's range as emitted
             // (they are included in the source extraction)

--- a/ext/rfmt/src/format/rules/if_unless.rs
+++ b/ext/rfmt/src/format/rules/if_unless.rs
@@ -337,6 +337,14 @@ fn format_normal(
                 docs.push(hardline());
                 docs.push(text("else"));
 
+                // Trailing comment on the else line (ElseNode starts at the
+                // `else` keyword)
+                let else_trailing =
+                    format_trailing_comment(ctx, consequent.location.start_line);
+                if !else_trailing.is_empty() {
+                    docs.push(else_trailing);
+                }
+
                 // Emit else body (first child of ElseNode)
                 if let Some(else_statements) = consequent.children.first() {
                     if matches!(else_statements.node_type, NodeType::StatementsNode) {

--- a/ext/rfmt/src/format/rules/if_unless.rs
+++ b/ext/rfmt/src/format/rules/if_unless.rs
@@ -339,8 +339,7 @@ fn format_normal(
 
                 // Trailing comment on the else line (ElseNode starts at the
                 // `else` keyword)
-                let else_trailing =
-                    format_trailing_comment(ctx, consequent.location.start_line);
+                let else_trailing = format_trailing_comment(ctx, consequent.location.start_line);
                 if !else_trailing.is_empty() {
                     docs.push(else_trailing);
                 }

--- a/ext/rfmt/src/format/rules/variable_write.rs
+++ b/ext/rfmt/src/format/rules/variable_write.rs
@@ -12,8 +12,8 @@ use crate::error::Result;
 use crate::format::context::FormatContext;
 use crate::format::registry::RuleRegistry;
 use crate::format::rule::{
-    format_child, format_leading_comments, format_trailing_comment,
-    mark_comments_in_range_emitted, reformat_chain_doc, strip_one_trailing_newline, FormatRule,
+    chain_doc_or_verbatim, format_child, format_leading_comments, format_trailing_comment,
+    mark_comments_in_range_emitted, FormatRule,
 };
 
 /// Rule for formatting local variable write expressions.
@@ -125,12 +125,7 @@ fn format_variable_write(
             // (`x = foo(<<~SQL)\n…\nSQL\n`) so it doesn't compound with the
             // surrounding hardline.
             if let Some(source_text) = ctx.extract_source(value) {
-                match reformat_chain_doc(source_text.trim_start()) {
-                    Some(chain_doc) => docs.push(chain_doc),
-                    None => docs.push(text(
-                        strip_one_trailing_newline(source_text.trim_start()).to_string(),
-                    )),
-                }
+                docs.push(chain_doc_or_verbatim(source_text.trim_start()));
                 // The extracted text carries any interior comments verbatim
                 // (e.g. inside a `do…end` block); without marking them they
                 // get re-emitted at EOF by format_remaining_comments.

--- a/ext/rfmt/src/format/rules/variable_write.rs
+++ b/ext/rfmt/src/format/rules/variable_write.rs
@@ -12,8 +12,8 @@ use crate::error::Result;
 use crate::format::context::FormatContext;
 use crate::format::registry::RuleRegistry;
 use crate::format::rule::{
-    format_child, format_leading_comments, format_trailing_comment, line_leading_indent,
-    mark_comments_in_range_emitted, reformat_chain_lines, strip_one_trailing_newline, FormatRule,
+    format_child, format_leading_comments, format_trailing_comment,
+    mark_comments_in_range_emitted, reformat_chain_doc, strip_one_trailing_newline, FormatRule,
 };
 
 /// Rule for formatting local variable write expressions.
@@ -125,14 +125,12 @@ fn format_variable_write(
             // (`x = foo(<<~SQL)\n…\nSQL\n`) so it doesn't compound with the
             // surrounding hardline.
             if let Some(source_text) = ctx.extract_source(value) {
-                let base_indent = line_leading_indent(ctx.source(), node.location.start_offset);
-                let reformatted = reformat_chain_lines(
-                    source_text,
-                    base_indent,
-                    ctx.config().formatting.indent_width,
-                );
-                let trimmed = strip_one_trailing_newline(reformatted.trim_start());
-                docs.push(text(trimmed.to_string()));
+                match reformat_chain_doc(source_text.trim_start()) {
+                    Some(chain_doc) => docs.push(chain_doc),
+                    None => docs.push(text(
+                        strip_one_trailing_newline(source_text.trim_start()).to_string(),
+                    )),
+                }
                 // The extracted text carries any interior comments verbatim
                 // (e.g. inside a `do…end` block); without marking them they
                 // get re-emitted at EOF by format_remaining_comments.

--- a/ext/rfmt/src/parser/native_adapter.rs
+++ b/ext/rfmt/src/parser/native_adapter.rs
@@ -58,6 +58,14 @@ impl RubyParser for NativeAdapter {
         // As in the bridge/PrismAdapter pipeline, all comments live in a flat
         // list on the root node; per-node comments stay empty.
         root.comments = root_comments(&parse_result, &index);
+        // The AST has no node for the `__END__` data section; record where it
+        // starts so the formatter can re-append the source slice verbatim.
+        if let Some(data_loc) = parse_result.data_loc() {
+            root.metadata.insert(
+                "data_start_offset".to_string(),
+                data_loc.start_offset().to_string(),
+            );
+        }
         Ok(root)
     }
 }

--- a/spec/chain_indent_idempotency_spec.rb
+++ b/spec/chain_indent_idempotency_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Rfmt, 'chain indent idempotency on misindented input' do
+  it 'indents chain continuations correctly in a single pass' do
+    source = <<~RUBY
+      def index
+      @posts = Post.published
+      .includes(:author)
+      .order(created_at: :desc)
+      end
+    RUBY
+
+    expected = <<~RUBY
+      def index
+        @posts = Post.published
+          .includes(:author)
+          .order(created_at: :desc)
+      end
+    RUBY
+
+    expect(Rfmt.format(source)).to eq(expected)
+  end
+
+  it 'is idempotent when the input statement is deeper than its output position' do
+    source = <<~RUBY
+      def index
+            @posts = Post.published
+              .includes(:author)
+              .order(created_at: :desc)
+      end
+    RUBY
+
+    first = Rfmt.format(source)
+    expect(Rfmt.format(first)).to eq(first), "non-idempotent output:\n#{first}"
+  end
+
+  it 'is idempotent for a nested misindented chain' do
+    source = <<~RUBY
+      module Api
+      class PostsController
+      def index
+      @posts = Post.published
+      .includes(:author)
+      .page(params[:page])
+      end
+      end
+      end
+    RUBY
+
+    first = Rfmt.format(source)
+    expect(Rfmt.format(first)).to eq(first), "non-idempotent output:\n#{first}"
+  end
+end

--- a/spec/chain_indent_idempotency_spec.rb
+++ b/spec/chain_indent_idempotency_spec.rb
@@ -32,7 +32,35 @@ RSpec.describe Rfmt, 'chain indent idempotency on misindented input' do
       end
     RUBY
 
+    expected = <<~RUBY
+      def index
+        @posts = Post.published
+          .includes(:author)
+          .order(created_at: :desc)
+      end
+    RUBY
+
     first = Rfmt.format(source)
+    expect(first).to eq(expected)
+    expect(Rfmt.format(first)).to eq(first), "non-idempotent output:\n#{first}"
+  end
+
+  it 'keeps plain heredoc body content byte-identical inside a reformatted chain' do
+    require 'prism'
+    source = "result = base\n      .where(<<SQL)\n        a = 1\nSQL\n      .order(:id)\n"
+
+    heredoc_contents = lambda do |code|
+      contents = []
+      collect = lambda do |node|
+        contents << node.unescaped if node.is_a?(Prism::StringNode)
+        node.compact_child_nodes.each { |child| collect.call(child) }
+      end
+      collect.call(Prism.parse(code).value)
+      contents
+    end
+
+    first = Rfmt.format(source)
+    expect(heredoc_contents.call(first)).to eq(heredoc_contents.call(source))
     expect(Rfmt.format(first)).to eq(first), "non-idempotent output:\n#{first}"
   end
 
@@ -49,7 +77,20 @@ RSpec.describe Rfmt, 'chain indent idempotency on misindented input' do
       end
     RUBY
 
+    expected = <<~RUBY
+      module Api
+        class PostsController
+          def index
+            @posts = Post.published
+              .includes(:author)
+              .page(params[:page])
+          end
+        end
+      end
+    RUBY
+
     first = Rfmt.format(source)
+    expect(first).to eq(expected)
     expect(Rfmt.format(first)).to eq(first), "non-idempotent output:\n#{first}"
   end
 end

--- a/spec/else_trailing_comment_spec.rb
+++ b/spec/else_trailing_comment_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Rfmt, 'trailing comment on else' do
       end
     RUBY
 
-    expect(Rfmt.format(source)).to include("else # inline on else\n")
+    expect(Rfmt.format(source)).to eq(source)
   end
 
   it 'keeps else comments inline alongside if and end comments' do
@@ -24,11 +24,15 @@ RSpec.describe Rfmt, 'trailing comment on else' do
       end # inline on end
     RUBY
 
-    formatted = Rfmt.format(source)
+    expected = <<~RUBY
+      result = if chain > 10 # inline on if
+        :big
+      else # inline on else
+        :small
+      end # inline on end
+    RUBY
 
-    expect(formatted).to include("# inline on if\n")
-    expect(formatted).to include("else # inline on else\n")
-    expect(formatted).to include("end # inline on end\n")
+    expect(Rfmt.format(source)).to eq(expected)
   end
 
   it 'keeps the comment on the else line inside unless' do
@@ -40,6 +44,6 @@ RSpec.describe Rfmt, 'trailing comment on else' do
       end
     RUBY
 
-    expect(Rfmt.format(source)).to include("else # fall through\n")
+    expect(Rfmt.format(source)).to eq(source)
   end
 end

--- a/spec/else_trailing_comment_spec.rb
+++ b/spec/else_trailing_comment_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Rfmt, 'trailing comment on else' do
+  it 'keeps the comment on the else line' do
+    source = <<~RUBY
+      if big?
+        :big
+      else # inline on else
+        :small
+      end
+    RUBY
+
+    expect(Rfmt.format(source)).to include("else # inline on else\n")
+  end
+
+  it 'keeps else comments inline alongside if and end comments' do
+    source = <<~RUBY
+      result = if chain > 10 # inline on if
+        :big
+      else # inline on else
+        :small
+      end # inline on end
+    RUBY
+
+    formatted = Rfmt.format(source)
+
+    expect(formatted).to include("# inline on if\n")
+    expect(formatted).to include("else # inline on else\n")
+    expect(formatted).to include("end # inline on end\n")
+  end
+
+  it 'keeps the comment on the else line inside unless' do
+    source = <<~RUBY
+      unless ready?
+        wait
+      else # fall through
+        run
+      end
+    RUBY
+
+    expect(Rfmt.format(source)).to include("else # fall through\n")
+  end
+end

--- a/spec/end_data_section_spec.rb
+++ b/spec/end_data_section_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Rfmt, '__END__ data section preservation' do
+  it 'keeps the __END__ line and everything after it' do
+    source = <<~RUBY
+      puts DATA.read
+
+      __END__
+      hello
+      world
+    RUBY
+
+    formatted = Rfmt.format(source)
+
+    expect(formatted).to end_with("__END__\nhello\nworld\n")
+  end
+
+  it 'preserves data content verbatim, including blank lines and indentation' do
+    source = "x = 1\n__END__\n  indented\n\nspaced  \n"
+
+    formatted = Rfmt.format(source)
+
+    expect(formatted[/^__END__\n(.*)/m, 1]).to eq("  indented\n\nspaced  \n")
+  end
+
+  it 'stays idempotent with a data section present' do
+    source = <<~RUBY
+      class SeedLoader
+        def load!
+          DATA.each_line { |line| Tag.create!(name: line.strip) }
+        end
+      end
+
+      __END__
+      ruby
+      rails
+    RUBY
+
+    first = Rfmt.format(source)
+    expect(Rfmt.format(first)).to eq(first)
+  end
+
+  it 'does not invent a data section when none exists' do
+    expect(Rfmt.format("x = 1\n")).not_to include('__END__')
+  end
+end


### PR DESCRIPTION
Three formatter bugs found by ad-hoc property testing over Rails-style code (crash / idempotency / AST equivalence / comment preservation, plus a DATA-section property the existing corpus check does not cover).

## What was broken

**The \`__END__\` data section was silently dropped.** \`Rfmt.format("puts DATA.read\n\n__END__\nhello\n")\` returned only \`"puts DATA.read\n"\`, destroying any script that reads \`DATA\`. The section is not part of Prism's AST, and the formatter rebuilds output from the AST, so nothing ever emitted it. Fix: \`NativeAdapter::parse\` records \`data_loc()\`'s start offset in the root metadata, and \`Formatter::format\` re-appends the verbatim source slice after printing. \`data_loc\` comes from Prism, so a fake \`__END__\` inside a heredoc cannot false-positive.

**Chain continuation indentation was not idempotent.** The chain reformatter baked the statement's *input* column into a \`Doc::Text\`, but the doc engine places the statement at its *output* position. On misindented input (conflict resolutions, generated code) the first pass under- or over-indented continuations and the second pass moved them again. Fix: \`reformat_chain_lines\` became \`reformat_chain_doc\`, emitting continuation lines as \`hardline\` docs inside \`indent(...)\` so the printer anchors them at render time. Multi-line arguments keep their offset relative to the chain; heredoc bodies are emitted through \`literalline\` verbatim, because for plain/dash heredocs the leading whitespace is string content (a lexical heredoc scanner marks those lines; ambiguity fails toward verbatim, the semantics-safe direction).

**A trailing comment on \`else\` moved below the line**, where it reads as annotating the branch body. The \`ElseNode\` arm never consumed the else-line comment as a trailing comment, so the body's leading-comment path claimed it. Fix mirrors the existing if-header and end-line handling.

## Verification

- Failing repro specs land first in history (\`spec/end_data_section_spec.rb\`, \`spec/chain_indent_idempotency_spec.rb\`, \`spec/else_trailing_comment_spec.rb\`), fixes on top.
- \`bundle exec rspec\`: 177 examples, 0 failures. \`cargo test\`: 139 + 5 + 3 passed. \`scripts/corpus_check.rb\`: 49/49.
- A 77-case Rails-idiom corpus (migrations, models, controllers, routes, jobs, RSpec, Rake DSL, mangled-indentation variants, lexical traps) passes all properties including the new DATA-section check.

## Known follow-ups (pre-existing, not regressions)

- A variable-assigned chain ending in a \`do…end\` block under-indents the block body on misindented input (output is stable and semantically equivalent).
- \`case/when\` and \`begin/rescue\` \`else\` lines still relocate their trailing comment; the fix here covers \`if\`/\`unless\`/\`elsif\` only.
- Two lexical heredoc detectors now coexist (\`heredoc_body_lines\` and \`statement_contains_heredoc_tail\` in if_unless.rs); the older, cruder one could be reimplemented on the new scanner.