### PR TITLE
Add data section preservation to the corpus check

### DIFF
--- a/scripts/corpus_check.rb
+++ b/scripts/corpus_check.rb
@@ -149,6 +149,10 @@ module CorpusCheck
         failures << "comment preservation: #{source_result.comments.size} comments in source, " \
                     "#{formatted_result.comments.size} in output"
       end
+      # The __END__ data section is outside the AST, so no other property sees its loss
+      if source_result.data_loc&.slice != formatted_result.data_loc&.slice
+        failures << 'data section preservation: __END__ content changed or dropped'
+      end
       failures.compact
     end
 

--- a/spec/fixtures/corpus/end_data_section.rb
+++ b/spec/fixtures/corpus/end_data_section.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Corpus sentinel: exercises the data-section preservation property on every
+# corpus check run (the __END__ section lives outside the AST).
+puts DATA.read
+
+__END__
+plain data line
+  indented line	with a tab
+
+trailing blank line above, no code below


### PR DESCRIPTION
Closes the safety-net gap acknowledged in #124: the `__END__` data section lives outside the AST, so a formatter that drops it passes all four existing corpus properties (syntactic validity, idempotency, AST equivalence, comment count). #124 fixed the formatter and added a targeted spec; this adds the property to the corpus check so any future regression path is caught, not just the known one.

- Fifth property: `data_loc&.slice` must be identical between input and output (Prism computes `data_loc`, so heredoc-embedded fake `__END__` cannot false-positive)
- Corpus sentinel `spec/fixtures/corpus/end_data_section.rb`: a real file with a data section (indentation, tab, blank line) that exercises the property on every run

Verified: the property reports a mismatch when the data section is removed (red proof against a synthetically stripped output); corpus check 50/50 green with the sentinel; rspec 177/0; rubocop clean.
