### PR TITLE
Release 2.0.0.beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [2.0.0.beta1] - 2026-07-22
+
 Parsing now happens natively in Rust. The Ruby-side Prism parse and JSON handoff have been replaced by the ruby-prism crate with prism statically linked into the extension; Ruby remains the CLI/LSP shell.
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,7 +486,7 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "rfmt"
-version = "1.7.0"
+version = "2.0.0-beta1"
 dependencies = [
  "dirs",
  "globset",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rfmt (1.7.0)
+    rfmt (2.0.0.beta1)
       diff-lcs (~> 1.5)
       diffy (~> 3.4)
       language_server-protocol (~> 3.17)

--- a/ext/rfmt/Cargo.toml
+++ b/ext/rfmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rfmt"
-version = "1.7.0"
+version = "2.0.0-beta1"
 edition = "2021"
 authors = ["fujitani sora <fujitanisora0414@gmail.com>"]
 license = "MIT"

--- a/ext/rfmt/src/lib.rs
+++ b/ext/rfmt/src/lib.rs
@@ -72,7 +72,7 @@ fn parse_to_json(ruby: &Ruby, source: String) -> Result<String, Error> {
 }
 
 fn rust_version() -> String {
-    "0.2.0 (Rust)".to_string()
+    format!("{} (Rust)", env!("CARGO_PKG_VERSION"))
 }
 
 #[magnus::init]

--- a/lib/rfmt/version.rb
+++ b/lib/rfmt/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Rfmt
-  VERSION = '1.7.0'
+  VERSION = '2.0.0.beta1'
 end


### PR DESCRIPTION
Version bump for the 2.0.0 beta release (codename v2, #110): native Rust parsing, ~22x in-process speedup, `--config` honored, atomic writes, output-validation guard, prism runtime dependency removed. Full notes in the CHANGELOG.

- `lib/rfmt/version.rb` → 2.0.0.beta1 (prerelease gem: not installed by default without `--pre`)
- Rust crate → 2.0.0-beta1; `Rfmt.rust_version` now derives from `CARGO_PKG_VERSION` instead of a hardcoded string
- CHANGELOG: Unreleased → 2.0.0.beta1 dated

After merge: tag `v2.0.0.beta1` on the merge commit triggers the release workflow (cross-builds all 7 platforms via the bindgen bridge, publishes to RubyGems).